### PR TITLE
[COOK-3358] Fix race condition caused by reload of postgresql.conf when bad data is introduced into pg_hba.conf

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -62,7 +62,7 @@ template "#{node['postgresql']['dir']}/postgresql.conf" do
   owner "postgres"
   group "postgres"
   mode 0600
-  notifies :reload, 'service[postgresql]'
+  notifies :reload, 'service[postgresql]', :delayed
 end
 
 template "#{node['postgresql']['dir']}/pg_hba.conf" do
@@ -70,7 +70,7 @@ template "#{node['postgresql']['dir']}/pg_hba.conf" do
   owner "postgres"
   group "postgres"
   mode 00600
-  notifies :reload, 'service[postgresql]'
+  notifies :reload, 'service[postgresql]', :delayed
 end
 
 # NOTE: Consider two facts before modifying "assign-postgres-password":

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -62,7 +62,7 @@ template "#{node['postgresql']['dir']}/postgresql.conf" do
   owner "postgres"
   group "postgres"
   mode 0600
-  notifies :reload, 'service[postgresql]', :immediately
+  notifies :reload, 'service[postgresql]'
 end
 
 template "#{node['postgresql']['dir']}/pg_hba.conf" do
@@ -70,7 +70,7 @@ template "#{node['postgresql']['dir']}/pg_hba.conf" do
   owner "postgres"
   group "postgres"
   mode 00600
-  notifies :reload, 'service[postgresql]', :immediately
+  notifies :reload, 'service[postgresql]'
 end
 
 # NOTE: Consider two facts before modifying "assign-postgres-password":


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3358

This patch changes the notifies to use the default delayed action to ensure both config files are on disk before attempting to reload. 