### PR TITLE
[COOK-3753] Fix dollar sign in password bug

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -84,7 +84,7 @@ end
 bash "assign-postgres-password" do
   user 'postgres'
   code <<-EOH
-echo "ALTER ROLE postgres ENCRYPTED PASSWORD '#{node['postgresql']['password']['postgres']}';" | psql
+echo 'ALTER ROLE postgres ENCRYPTED PASSWORD '"'"'#{node['postgresql']['password']['postgres']}'"'"';' | psql
   EOH
   action :run
 end


### PR DESCRIPTION
When there is a dollar sign in password, it will be set wrongly (interpreted as environment variable). For example

```
echo "ALTER ROLE postgres ENCRYPTED PASSWORD 'MY_SUPER_$PWD';"
```

will become

```
ALTER ROLE postgres ENCRYPTED PASSWORD 'MY_SUPER_/path/to/pwd';
```
