### PR TITLE
Added initialization of an alternate Postgres data_directory for Ubuntu

### DIFF
--- a/recipes/server_debian.rb
+++ b/recipes/server_debian.rb
@@ -27,6 +27,32 @@ node['postgresql']['server']['packages'].each do |pg_pack|
 
 end
 
+directory node['postgresql']['config']['data_directory'] do
+  recursive true
+  owner 'postgres'
+  group 'postgres'
+  mode '0700'
+end
+
+ruby_block "creating initial data directory" do
+  block do
+    FileUtils.cp_r(Dir["/var/lib/postgresql/#{node['postgresql']['version']}/main/*"], node['postgresql']['config']['data_directory'])
+  end
+  only_if { Dir["#{node['postgresql']['config']['data_directory']}/*"].empty? }
+end
+
+execute "chown data dir to postgres" do
+  command "chown -R postgres:postgres #{node['postgresql']['config']['data_directory']}"
+  user "root"
+  action :run
+end
+
+execute "chmod data dir to postgres" do
+  command "chmod -R 700 #{node['postgresql']['config']['data_directory']}"
+  user "root"
+  action :run
+end
+
 service "postgresql" do
   service_name node['postgresql']['server']['service_name']
   supports :restart => true, :status => true, :reload => true


### PR DESCRIPTION
This is a patch for https://github.com/hw-cookbooks/postgresql/issues/143.  It's not perfect, but it gets the job done for my Debian-specific usecase and could probably be adapted for RedHat fairly easily.

I added a few blocks to conditionally copy default Debian Postgres data_directory files generated from the package manager's installation of postgres to the custom data_directory specified by the existing `node['postgresql']['config']['data_directory]` attribute if it's empty.

This could probably done by calling `initdb` in this directory as well, but I wanted to set it up so that a server already using the default databases would also have its files moved in an idempotent way.  I submitted this PR just incase the core team/maintainers want a band aid until a more generalized solution is developed they can use this.