### PR TITLE
Define version-sensitive attributes in a recipe

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -31,18 +31,6 @@ when "debian"
     default['postgresql']['version'] = "9.1"
   end
 
-  default['postgresql']['dir'] = "/etc/postgresql/#{node['postgresql']['version']}/main"
-  case
-  when node['platform_version'].to_f < 6.0 # All 5.X
-    default['postgresql']['server']['service_name'] = "postgresql-#{node['postgresql']['version']}"
-  else
-    default['postgresql']['server']['service_name'] = "postgresql"
-  end
-
-  default['postgresql']['client']['packages'] = ["postgresql-client-#{node['postgresql']['version']}","libpq-dev"]
-  default['postgresql']['server']['packages'] = ["postgresql-#{node['postgresql']['version']}"]
-  default['postgresql']['contrib']['packages'] = ["postgresql-contrib-#{node['postgresql']['version']}"]
-
 when "ubuntu"
 
   case
@@ -56,18 +44,6 @@ when "ubuntu"
     default['postgresql']['version'] = "9.3"
   end
 
-  default['postgresql']['dir'] = "/etc/postgresql/#{node['postgresql']['version']}/main"
-  case
-  when (node['platform_version'].to_f <= 10.04) && (! node['postgresql']['enable_pgdg_apt'])
-    default['postgresql']['server']['service_name'] = "postgresql-#{node['postgresql']['version']}"
-  else
-    default['postgresql']['server']['service_name'] = "postgresql"
-  end
-
-  default['postgresql']['client']['packages'] = ["postgresql-client-#{node['postgresql']['version']}","libpq-dev"]
-  default['postgresql']['server']['packages'] = ["postgresql-#{node['postgresql']['version']}"]
-  default['postgresql']['contrib']['packages'] = ["postgresql-contrib-#{node['postgresql']['version']}"]
-
 when "fedora"
 
   if node['platform_version'].to_f <= 12
@@ -76,62 +52,24 @@ when "fedora"
     default['postgresql']['version'] = "8.4"
   end
 
-  default['postgresql']['dir'] = "/var/lib/pgsql/data"
-  default['postgresql']['client']['packages'] = %w{postgresql-devel}
-  default['postgresql']['server']['packages'] = %w{postgresql-server}
-  default['postgresql']['contrib']['packages'] = %w{postgresql-contrib}
-  default['postgresql']['server']['service_name'] = "postgresql"
-
 when "amazon"
 
   if node['platform_version'].to_f >= 2012.03
     default['postgresql']['version'] = "9.0"
-    default['postgresql']['dir'] = "/var/lib/pgsql9/data"
   else
     default['postgresql']['version'] = "8.4"
-    default['postgresql']['dir'] = "/var/lib/pgsql/data"
   end
-
-  default['postgresql']['client']['packages'] = %w{postgresql-devel}
-  default['postgresql']['server']['packages'] = %w{postgresql-server}
-  default['postgresql']['contrib']['packages'] = %w{postgresql-contrib}
-  default['postgresql']['server']['service_name'] = "postgresql"
 
 when "redhat", "centos", "scientific", "oracle"
 
   default['postgresql']['version'] = "8.4"
-  default['postgresql']['dir'] = "/var/lib/pgsql/data"
-
-  if node['platform_version'].to_f >= 6.0 && node['postgresql']['version'] == '8.4'
-    default['postgresql']['client']['packages'] = %w{postgresql-devel}
-    default['postgresql']['server']['packages'] = %w{postgresql-server}
-    default['postgresql']['contrib']['packages'] = %w{postgresql-contrib}
-  else
-    default['postgresql']['client']['packages'] = ["postgresql#{node['postgresql']['version'].split('.').join}-devel"]
-    default['postgresql']['server']['packages'] = ["postgresql#{node['postgresql']['version'].split('.').join}-server"]
-    default['postgresql']['contrib']['packages'] = ["postgresql#{node['postgresql']['version'].split('.').join}-contrib"]
-  end
-
-  if node['platform_version'].to_f >= 6.0 && node['postgresql']['version'] != '8.4'
-     default['postgresql']['dir'] = "/var/lib/pgsql/#{node['postgresql']['version']}/data"
-     default['postgresql']['server']['service_name'] = "postgresql-#{node['postgresql']['version']}"
-  else
-    default['postgresql']['dir'] = "/var/lib/pgsql/data"
-    default['postgresql']['server']['service_name'] = "postgresql"
-  end
 
 when "suse"
 
   if node['platform_version'].to_f <= 11.1
     default['postgresql']['version'] = "8.3"
-    default['postgresql']['client']['packages'] = ['postgresql', 'rubygem-pg']
-    default['postgresql']['server']['packages'] = ['postgresql-server']
-    default['postgresql']['contrib']['packages'] = ['postgresql-contrib']
   else
     default['postgresql']['version'] = "9.1"
-    default['postgresql']['client']['packages'] = ['postgresql91', 'rubygem-pg']
-    default['postgresql']['server']['packages'] = ['postgresql91-server']
-    default['postgresql']['contrib']['packages'] = ['postgresql91-contrib']
   end
 
   default['postgresql']['dir'] = "/var/lib/pgsql/data"
@@ -139,11 +77,6 @@ when "suse"
 
 else
   default['postgresql']['version'] = "8.4"
-  default['postgresql']['dir']         = "/etc/postgresql/#{node['postgresql']['version']}/main"
-  default['postgresql']['client']['packages'] = ["postgresql"]
-  default['postgresql']['server']['packages'] = ["postgresql"]
-  default['postgresql']['contrib']['packages'] = ["postgresql"]
-  default['postgresql']['server']['service_name'] = "postgresql"
 end
 
 # These defaults have disparity between which postgresql configuration
@@ -160,23 +93,14 @@ end
 # merge/precedence order during the Chef run.
 case node['platform_family']
 when 'debian'
-  default['postgresql']['config']['data_directory'] = "/var/lib/postgresql/#{node['postgresql']['version']}/main"
-  default['postgresql']['config']['hba_file'] = "/etc/postgresql/#{node['postgresql']['version']}/main/pg_hba.conf"
-  default['postgresql']['config']['ident_file'] = "/etc/postgresql/#{node['postgresql']['version']}/main/pg_ident.conf"
-  default['postgresql']['config']['external_pid_file'] = "/var/run/postgresql/#{node['postgresql']['version']}-main.pid"
   default['postgresql']['config']['listen_addresses'] = 'localhost'
   default['postgresql']['config']['port'] = 5432
   default['postgresql']['config']['max_connections'] = 100
-  default['postgresql']['config']['unix_socket_directory'] = '/var/run/postgresql' if node['postgresql']['version'].to_f < 9.3
-  default['postgresql']['config']['unix_socket_directories'] = '/var/run/postgresql' if node['postgresql']['version'].to_f >= 9.3
   default['postgresql']['config']['shared_buffers'] = '24MB'
-  default['postgresql']['config']['max_fsm_pages'] = 153600 if node['postgresql']['version'].to_f < 8.4
   default['postgresql']['config']['log_line_prefix'] = '%t '
   default['postgresql']['config']['datestyle'] = 'iso, mdy'
   default['postgresql']['config']['default_text_search_config'] = 'pg_catalog.english'
   default['postgresql']['config']['ssl'] = true
-  default['postgresql']['config']['ssl_cert_file'] = '/etc/ssl/certs/ssl-cert-snakeoil.pem' if node['postgresql']['version'].to_f >= 9.2
-  default['postgresql']['config']['ssl_key_file'] = '/etc/ssl/private/ssl-cert-snakeoil.key'if node['postgresql']['version'].to_f >= 9.2
 when 'rhel', 'fedora', 'suse'
   default['postgresql']['config']['data_directory'] = node['postgresql']['dir']
   default['postgresql']['config']['listen_addresses'] = 'localhost'

--- a/recipes/apt_pgdg_postgresql.rb
+++ b/recipes/apt_pgdg_postgresql.rb
@@ -2,6 +2,7 @@ if not %w(squeeze wheezy sid lucid precise saucy trusty).include? node['postgres
   raise "Not supported release by PGDG apt repository"
 end
 
+include_recipe 'postgresql::config_version'
 include_recipe 'apt'
 
 file "remove deprecated Pitti PPA apt repository" do

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+include_recipe 'postgresql::config_version'
+
 if platform_family?('debian') && node['postgresql']['version'].to_f > 9.3
   node.default['postgresql']['enable_pgdg_apt'] = true
 end

--- a/recipes/config_initdb.rb
+++ b/recipes/config_initdb.rb
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+include_recipe 'postgresql::config_version'
+
 #######
 # Load the locale_date_order() and select_default_timezone(tzdir)
 # methods from libraries/default.rb

--- a/recipes/config_version.rb
+++ b/recipes/config_version.rb
@@ -1,0 +1,135 @@
+#
+# Cookbook Name:: postgresql
+# Recipe:: config_version
+#
+# Defines version-sensitive default attributes after all other attributes files
+# have been evaluated, allowing users of this cookbook to use default
+# attributes in attribute files to set the postgresql version and still have
+# sensible defaults for everything.
+#
+# To override any attribute defined in this recipe using an attribute file,
+# you must use force_default or higher. See
+# https://docs.getchef.com/essentials_cookbook_attribute_files.html for info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+case node['platform']
+when "debian"
+
+  node.default['postgresql']['dir'] = "/etc/postgresql/#{node['postgresql']['version']}/main"
+  case
+  when node['platform_version'].to_f < 6.0 # All 5.X
+    node.default['postgresql']['server']['service_name'] = "postgresql-#{node['postgresql']['version']}"
+  else
+    node.default['postgresql']['server']['service_name'] = "postgresql"
+  end
+
+  node.default['postgresql']['client']['packages'] = ["postgresql-client-#{node['postgresql']['version']}","libpq-dev"]
+  node.default['postgresql']['server']['packages'] = ["postgresql-#{node['postgresql']['version']}"]
+  node.default['postgresql']['contrib']['packages'] = ["postgresql-contrib-#{node['postgresql']['version']}"]
+
+when "ubuntu"
+
+  node.default['postgresql']['dir'] = "/etc/postgresql/#{node['postgresql']['version']}/main"
+  case
+  when (node['platform_version'].to_f <= 10.04) && (! node['postgresql']['enable_pgdg_apt'])
+    node.default['postgresql']['server']['service_name'] = "postgresql-#{node['postgresql']['version']}"
+  else
+    node.default['postgresql']['server']['service_name'] = "postgresql"
+  end
+
+  node.default['postgresql']['client']['packages'] = ["postgresql-client-#{node['postgresql']['version']}","libpq-dev"]
+  node.default['postgresql']['server']['packages'] = ["postgresql-#{node['postgresql']['version']}"]
+  node.default['postgresql']['contrib']['packages'] = ["postgresql-contrib-#{node['postgresql']['version']}"]
+
+when "fedora"
+
+  node.default['postgresql']['dir'] = "/var/lib/pgsql/data"
+  node.default['postgresql']['client']['packages'] = %w{postgresql-devel}
+  node.default['postgresql']['server']['packages'] = %w{postgresql-server}
+  node.default['postgresql']['contrib']['packages'] = %w{postgresql-contrib}
+  node.default['postgresql']['server']['service_name'] = "postgresql"
+
+when "amazon"
+
+  if node['platform_version'].to_f >= 2012.03
+    node.default['postgresql']['version'] = "9.0"
+    node.default['postgresql']['dir'] = "/var/lib/pgsql9/data"
+  else
+    node.default['postgresql']['version'] = "8.4"
+    node.default['postgresql']['dir'] = "/var/lib/pgsql/data"
+  end
+
+  node.default['postgresql']['client']['packages'] = %w{postgresql-devel}
+  node.default['postgresql']['server']['packages'] = %w{postgresql-server}
+  node.default['postgresql']['contrib']['packages'] = %w{postgresql-contrib}
+  node.default['postgresql']['server']['service_name'] = "postgresql"
+
+when "redhat", "centos", "scientific", "oracle"
+
+  node.default['postgresql']['dir'] = "/var/lib/pgsql/data"
+
+  if node['platform_version'].to_f >= 6.0 && node['postgresql']['version'] == '8.4'
+    node.default['postgresql']['client']['packages'] = %w{postgresql-devel}
+    node.default['postgresql']['server']['packages'] = %w{postgresql-server}
+    node.default['postgresql']['contrib']['packages'] = %w{postgresql-contrib}
+  else
+    node.default['postgresql']['client']['packages'] = ["postgresql#{node['postgresql']['version'].split('.').join}-devel"]
+    node.default['postgresql']['server']['packages'] = ["postgresql#{node['postgresql']['version'].split('.').join}-server"]
+    node.default['postgresql']['contrib']['packages'] = ["postgresql#{node['postgresql']['version'].split('.').join}-contrib"]
+  end
+
+  if node['platform_version'].to_f >= 6.0 && node['postgresql']['version'] != '8.4'
+     node.default['postgresql']['dir'] = "/var/lib/pgsql/#{node['postgresql']['version']}/data"
+     node.default['postgresql']['server']['service_name'] = "postgresql-#{node['postgresql']['version']}"
+  else
+    node.default['postgresql']['dir'] = "/var/lib/pgsql/data"
+    node.default['postgresql']['server']['service_name'] = "postgresql"
+  end
+
+when "suse"
+
+  if node['postgresql']['version'] = '8.3'
+    node.default['postgresql']['client']['packages'] = ['postgresql', 'rubygem-pg']
+    node.default['postgresql']['server']['packages'] = ['postgresql-server']
+    node.default['postgresql']['contrib']['packages'] = ['postgresql-contrib']
+  elsif node['postgresql']['version'] == '9.1'
+    node.default['postgresql']['client']['packages'] = ['postgresql91', 'rubygem-pg']
+    node.default['postgresql']['server']['packages'] = ['postgresql91-server']
+    node.default['postgresql']['contrib']['packages'] = ['postgresql91-contrib']
+  end
+
+  node.default['postgresql']['dir'] = "/var/lib/pgsql/data"
+  node.default['postgresql']['server']['service_name'] = "postgresql"
+
+else
+  node.default['postgresql']['dir'] = "/etc/postgresql/#{node['postgresql']['version']}/main"
+  node.default['postgresql']['client']['packages'] = ["postgresql"]
+  node.default['postgresql']['server']['packages'] = ["postgresql"]
+  node.default['postgresql']['contrib']['packages'] = ["postgresql"]
+  node.default['postgresql']['server']['service_name'] = "postgresql"
+end
+
+case node[:platform_family]
+when 'debian'
+  node.default['postgresql']['config']['data_directory'] = "/var/lib/postgresql/#{node['postgresql']['version']}/main"
+  node.default['postgresql']['config']['hba_file'] = "/etc/postgresql/#{node['postgresql']['version']}/main/pg_hba.conf"
+  node.default['postgresql']['config']['ident_file'] = "/etc/postgresql/#{node['postgresql']['version']}/main/pg_ident.conf"
+  node.default['postgresql']['config']['external_pid_file'] = "/var/run/postgresql/#{node['postgresql']['version']}-main.pid"
+  node.default['postgresql']['config']['unix_socket_directory'] = '/var/run/postgresql' if node['postgresql']['version'].to_f < 9.3
+  node.default['postgresql']['config']['unix_socket_directories'] = '/var/run/postgresql' if node['postgresql']['version'].to_f >= 9.3
+  node.default['postgresql']['config']['max_fsm_pages'] = 153600 if node['postgresql']['version'].to_f < 8.4
+  node.default['postgresql']['config']['ssl_cert_file'] = '/etc/ssl/certs/ssl-cert-snakeoil.pem' if node['postgresql']['version'].to_f >= 9.2
+  node.default['postgresql']['config']['ssl_key_file'] = '/etc/ssl/private/ssl-cert-snakeoil.key'if node['postgresql']['version'].to_f >= 9.2
+end

--- a/recipes/contrib.rb
+++ b/recipes/contrib.rb
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+include_recipe 'postgresql::config_version'
 include_recipe "postgresql::server"
 
 # Install the PostgreSQL contrib package(s) from the distribution,

--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+include_recipe 'postgresql::config_version'
+
 # Load the pgdgrepo_rpm_info method from libraries/default.rb
 ::Chef::Recipe.send(:include, Opscode::PostgresqlHelpers)
 

--- a/recipes/server_debian.rb
+++ b/recipes/server_debian.rb
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+include_recipe 'postgresql::config_version'
 include_recipe "postgresql::client"
 
 node['postgresql']['server']['packages'].each do |pg_pack|

--- a/recipes/server_redhat.rb
+++ b/recipes/server_redhat.rb
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+include_recipe 'postgresql::config_version'
 include_recipe "postgresql::client"
 
 svc_name = node['postgresql']['server']['service_name']

--- a/recipes/yum_pgdg_postgresql.rb
+++ b/recipes/yum_pgdg_postgresql.rb
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+include_recipe 'postgresql::config_version'
+
 #######
 # Load the pgdgrepo_rpm_info method from libraries/default.rb
 ::Chef::Recipe.send(:include, Opscode::PostgresqlHelpers)


### PR DESCRIPTION
    This allows the postgresql cookbook to continue working after default
    attributes are used to set the postgresql version. The postgresql
    version is used to create many other attributes containing that version
    number.
    
    By defining these version-sensitive attributes in a recipe, they can
    safely be defined knowing that all attributes files have already been
    loaded and that node[:postgresql][:version] has its final value.
    
    Otherwise, setting a default postgresql version in an attribute file
    outside the cookbook has no coherent effect.
    
    A caveat of this is that you can't override any config_version
    attributes anymore using default attributes defined in attribute files.
    You have to use force_default. But it turns out that most of these
    attributes should not really be changed, except for the postgresql.conf
    fields.
