### PR TITLE
Changed hard coded value to attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,6 +19,9 @@ default['postgresql']['enable_pgdg_apt'] = false
 default['postgresql']['server']['config_change_notify'] = :restart
 default['postgresql']['assign_postgres_password'] = true
 
+# Establish default database name
+default['postgresql']['database_name'] = 'template1'
+
 case node['platform']
 when "debian"
 

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -307,17 +307,18 @@ def get_result_orig(query)
 end
 
 #######
-# Function to execute an SQL statement in the template1 database.
+# Function to execute an SQL statement in the default database.
 #   Input: Query could be a single String or an Array of String.
 #   Output: A String with |-separated columns and \n-separated rows.
 #           Note an empty output could mean psql couldn't connect.
 # This is easiest for 1-field (1-row, 1-col) results, otherwise
 # it will be complex to parse the results.
 def execute_sql(query)
+  db_name = node['postgresql']['database_name']
   # query could be a String or an Array of String
   statement = query.is_a?(String) ? query : query.join("\n")
   @execute_sql ||= begin
-    cmd = shell_out("psql -q --tuples-only --no-align -d template1 -f -",
+    cmd = shell_out("psql -q --tuples-only --no-align -d #{db_name} -f -",
           :user => "postgres",
           :input => statement
     )

--- a/recipes/contrib.rb
+++ b/recipes/contrib.rb
@@ -17,6 +17,8 @@
 
 include_recipe "postgresql::server"
 
+db_name = node['postgresql']['database_name']
+
 # Install the PostgreSQL contrib package(s) from the distribution,
 # as specified by the node attributes.
 node['postgresql']['contrib']['packages'].each do |pg_pack|
@@ -25,14 +27,14 @@ node['postgresql']['contrib']['packages'].each do |pg_pack|
 
 end
 
-# Install PostgreSQL contrib extentions into the template1 database,
-# as specified by the node attributes.
+# Install PostgreSQL contrib extentions into the database, as specified by the
+# node attribute node['postgresql']['database_name'].
 if (node['postgresql']['contrib'].attribute?('extensions'))
   node['postgresql']['contrib']['extensions'].each do |pg_ext|
     bash "install-#{pg_ext}-extension" do
       user 'postgres'
       code <<-EOH
-        echo 'CREATE EXTENSION IF NOT EXISTS "#{pg_ext}";' | psql -d template1
+        echo 'CREATE EXTENSION IF NOT EXISTS "#{pg_ext}";' | psql -d "#{db_name}"
       EOH
       action :run
       ::Chef::Resource.send(:include, Opscode::PostgresqlHelpers)


### PR DESCRIPTION
Was utilizing contrib to install an extension and noticed that the recipe defines 'template1' for the postgres database.  To make the adjustable for various use cases, I created a new attribute to replace hard coded instances of 'template1'.