### PR TITLE
Startup fails if when /var/lib/pgsql/data is non-empty

### DIFF
--- a/recipes/server_conf.rb
+++ b/recipes/server_conf.rb
@@ -22,7 +22,7 @@ template "#{node['postgresql']['dir']}/postgresql.conf" do
   owner "postgres"
   group "postgres"
   mode 0600
-  notifies change_notify, 'service[postgresql]', :delayed
+  notifies change_notify, 'service[postgresql]', :immediately
 end
 
 template "#{node['postgresql']['dir']}/pg_hba.conf" do
@@ -30,5 +30,5 @@ template "#{node['postgresql']['dir']}/pg_hba.conf" do
   owner "postgres"
   group "postgres"
   mode 00600
-  notifies change_notify, 'service[postgresql]', :delayed
+  notifies change_notify, 'service[postgresql]', :immediately
 end

--- a/recipes/server_redhat.rb
+++ b/recipes/server_redhat.rb
@@ -77,7 +77,7 @@ if platform_family?("fedora") and node['platform_version'].to_i >= 16
     not_if { ::FileTest.exist?(File.join(dir, "PG_VERSION")) }
   end
 
-else !platform_family?("suse") 
+elsif !platform_family?("suse")
 
   execute "/sbin/service #{svc_name} initdb #{initdb_locale}" do
     not_if { ::FileTest.exist?(File.join(dir, "PG_VERSION")) }

--- a/recipes/server_redhat.rb
+++ b/recipes/server_redhat.rb
@@ -85,10 +85,11 @@ elsif !platform_family?("suse")
 
 end
 
-include_recipe "postgresql::server_conf"
 
 service "postgresql" do
   service_name svc_name
   supports :restart => true, :status => true, :reload => true
   action [:enable, :start]
 end
+
+include_recipe "postgresql::server_conf"


### PR DESCRIPTION
On OpenSUSE 13.1, startup fails if when /var/lib/pgsql/data is non-empty

* Changed the time when the configuration files are placed into the directory to be after the first start of the server.
 
* Subsequently changed the notifies to :immediately, otherwise changes I'd made to these files would not have been taken into account. I believe this is better than making whoever's using the cookbook/recipe explicitly have to restart the service if they've made any changes to conf files.