### PR TITLE
Support for server installation with systemd in RHEL based distributions

### DIFF
--- a/recipes/config_version.rb
+++ b/recipes/config_version.rb
@@ -61,6 +61,12 @@ when "fedora"
   node.default['postgresql']['contrib']['packages'] = %w{postgresql-contrib}
   node.default['postgresql']['server']['service_name'] = "postgresql"
 
+  if node['postgresql']['version'] == '9.3'
+     node.default['postgresql']['setup_script'] = "/usr/pgsql-#{node['postgresql']['version']}/bin/postgresql#{node['postgresql']['version'].split('.').join}-setup"
+  else
+     node.default['postgresql']['setup_script'] = "postgresql-setup"
+  end
+
 when "amazon"
 
   if node['platform_version'].to_f >= 2012.03
@@ -96,6 +102,12 @@ when "redhat", "centos", "scientific", "oracle"
   else
     node.default['postgresql']['dir'] = "/var/lib/pgsql/data"
     node.default['postgresql']['server']['service_name'] = "postgresql"
+  end
+
+  if node['postgresql']['version'] == '9.3'
+     node.default['postgresql']['setup_script'] = "/usr/pgsql-#{node['postgresql']['version']}/bin/postgresql#{node['postgresql']['version'].split('.').join}-setup"
+  else
+     node.default['postgresql']['setup_script'] = "postgresql-setup"
   end
 
 when "suse"

--- a/recipes/server_redhat.rb
+++ b/recipes/server_redhat.rb
@@ -52,11 +52,13 @@ node['postgresql']['server']['packages'].each do |pg_pack|
 
 end
 
-# Starting with Fedora 16, the pgsql sysconfig files are no longer used.
+# Starting with Fedora 16, the pgsql sysconfig files are no longer used,
+# its use is discouraged if using systemd
 # The systemd unit file does not support 'initdb' or 'upgrade' actions.
 # Use the postgresql-setup script instead.
+# Checks Ohai 7 node[:init_package] attribute
 
-unless platform_family?("fedora") and node['platform_version'].to_i >= 16
+unless node['init_package'] == 'systemd'
 
   directory "/etc/sysconfig/pgsql" do
     mode "0644"
@@ -72,13 +74,13 @@ unless platform_family?("fedora") and node['platform_version'].to_i >= 16
 
 end
 
-if platform_family?("fedora") and node['platform_version'].to_i >= 16
+if node['init_package'] == 'systemd'
 
-  execute "postgresql-setup initdb #{svc_name}" do
+  execute "#{node['postgresql']['setup_script']} initdb #{svc_name}" do
     not_if { ::FileTest.exist?(File.join(dir, "PG_VERSION")) }
   end
 
-else !platform_family?("suse") 
+else !platform_family?("suse")
 
   execute "/sbin/service #{svc_name} initdb #{initdb_locale}" do
     not_if { ::FileTest.exist?(File.join(dir, "PG_VERSION")) }


### PR DESCRIPTION
Use of postgresql-setup should be applied to all linux distributions using systemd (RHEL 7, for example). Otherwise installing PostgreSQL in Centos 7.0, among others, will fail (as it is not allowed to user service with initdb); in fact, at least in my case, kitchen test in this plaftform was failing.

I used the node attribute "init_package", I think it's more appropiate. 

Also I noticed that postgresql-setup is not always available in PATH, at least in PostgreSQL 9.3, even the script name is different. So I added a new attribute for this 'setup_script'. Maybe an alternative is the more general **initdb** script located in the same bin dir. I believe it's common on all platforms. I have not tried this approach however.