### PR TITLE
Debian Jessie has 9.4

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -31,7 +31,7 @@ when "debian"
   when node['platform_version'].to_f < 7.0 # All 6.X
     default['postgresql']['version'] = "8.4"
   else
-    default['postgresql']['version'] = "9.1"
+    default['postgresql']['version'] = "9.4"
   end
 
   default['postgresql']['dir'] = "/etc/postgresql/#{node['postgresql']['version']}/main"

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-if platform_family?('debian') && node['postgresql']['version'].to_f > 9.3
+if platform_family?('debian') && node['postgresql']['version'].to_f > 9.4
   node.default['postgresql']['enable_pgdg_apt'] = true
 end
 


### PR DESCRIPTION
Dead simple change. I'll leave PGDG support to someone else, this just gets the regular package working.