### PR TITLE
Fix contrib installation order

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -132,3 +132,44 @@ suites:
       version: "9.3"
       client:
         packages: ["postgresql93", "postgresql93-devel"]
+
+- name: apt-pgdg-server-pg_stat_statements
+  run_list:
+  - recipe[minitest-handler]
+  - recipe[postgresql::ruby]
+  - recipe[postgresql::contrib]
+  excludes: ["centos-5.9", "centos-6.4"]
+  attributes:
+    postgresql:
+      enable_pgdg_apt: true
+      version: "9.3"
+      password:
+        postgres: "iloverandompasswordsbutthiswilldo"
+      config:
+        shared_preload_libraries: "pg_stat_statements"
+        ssl_cert_file: "/etc/ssl/certs/ssl-cert-snakeoil.pem"
+        ssl_key_file: "/etc/ssl/private/ssl-cert-snakeoil.key"
+      contrib:
+        extensions:
+          - pg_stat_statements
+
+- name: yum-pgdg-server-pg_stat_statements
+  run_list:
+  - recipe[minitest-handler]
+  - recipe[postgresql::ruby]
+  - recipe[postgresql::contrib]
+  excludes: ["ubuntu-10.04", "ubuntu-12.04", "debian-7.1.0"]
+  attributes:
+    postgresql:
+      enable_pgdg_yum: true
+      version: "9.3"
+      server:
+        packages: ["postgresql93-server"]
+        service_name: "postgresql-9.3"
+      password:
+        postgres: "iloverandompasswordsbutthiswilldo"
+      config:
+        shared_preload_libraries: "pg_stat_statements"
+      contrib:
+        extensions:
+          - pg_stat_statements

--- a/README.md
+++ b/README.md
@@ -337,6 +337,10 @@ loads its shared library, which can be done with this node attribute:
 
     node['postgresql']['config']['shared_preload_libraries'] = 'pg_stat_statements'
 
+If using `shared_preload_libraries` in combination with the `contrib` recipe,
+make sure that the `contrib` recipe is called before the `server` recipe (to
+ensure the dependencies are installed and setup in order).
+
 apt\_pgdg\_postgresql
 ----------------------
 

--- a/recipes/contrib.rb
+++ b/recipes/contrib.rb
@@ -15,8 +15,6 @@
 # limitations under the License.
 #
 
-include_recipe "postgresql::server"
-
 db_name = node['postgresql']['database_name']
 
 # Install the PostgreSQL contrib package(s) from the distribution,
@@ -26,6 +24,8 @@ node['postgresql']['contrib']['packages'].each do |pg_pack|
   package pg_pack
 
 end
+
+include_recipe "postgresql::server"
 
 # Install PostgreSQL contrib extentions into the database, as specified by the
 # node attribute node['postgresql']['database_name'].


### PR DESCRIPTION
This fixes https://github.com/hw-cookbooks/postgresql/issues/192

pg_stat_statements requires the `shared_preload_libraries` setting to be set. However, on the first install, this was writing to postgresql.conf which forced an immediate start or restart of postgresql. But at that point, the contrib packages weren't actually installed, so this would cause postgresql to fail to startup (since, for example, the `pg_stat_statements` extension trying to be preloaded didn't actually exist yet). By shifting the installation of the contrib packages to before the server, this allows the dependencies to be installed before the server needs them.

This adds some kitchen testing surrounding the `pg_stat_statements` and `shared_preload_libraries` to ensure this combination installs successfully.

It also updates the README to make note of the fact that you still need to be a little careful if you're explicitly including both the `server` and `contrib` recipes, since the `contrib` recipe must come first.