### PR TITLE
Run restart command right away on the postgresql service.

### DIFF
--- a/recipes/server_debian.rb
+++ b/recipes/server_debian.rb
@@ -28,7 +28,7 @@ include_recipe "postgresql::server_conf"
 service "postgresql" do
   service_name node['postgresql']['server']['service_name']
   supports :restart => true, :status => true, :reload => true
-  action [:enable, :start]
+  action [:enable, :start, :restart]
 end
 
 execute 'Set locale and Create cluster' do


### PR DESCRIPTION
This fixes errors when using docker, without it the error `psql: could not connect to server: no such file or directory` is displayed when this recipe is used with docker and chef-solo. This is the same issue that is affecting https://github.com/hw-cookbooks/postgresql/pull/206#issuecomment-63587051 however I feel firing 1 restart is better than firing 1 for each configuration change.

It seems to me that the issue here is most likely that the server is started by default however does not have the proper configuration and thus connecting fails. This should not break any existing functionality.