### PR TITLE
Removed hardcoded UID/GID for RHEL systems

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -73,6 +73,9 @@ when "ubuntu"
 
 when "fedora"
 
+  default['postgresql']['uid'] = "26"
+  default['postgresql']['gid'] = "26"
+
   if node['platform_version'].to_f <= 12
     default['postgresql']['version'] = "8.3"
   else
@@ -102,6 +105,8 @@ when "amazon"
 
 when "redhat", "centos", "scientific", "oracle"
 
+  default['postgresql']['uid'] = "26"
+  default['postgresql']['gid'] = "26"
   default['postgresql']['version'] = "8.4"
   default['postgresql']['dir'] = "/var/lib/pgsql/data"
 
@@ -124,6 +129,9 @@ when "redhat", "centos", "scientific", "oracle"
   end
 
 when "suse"
+
+  default['postgresql']['uid'] = "26"
+  default['postgresql']['gid'] = "26"
 
   if node['platform_version'].to_f <= 11.1
     default['postgresql']['version'] = "8.3"

--- a/recipes/server_redhat.rb
+++ b/recipes/server_redhat.rb
@@ -25,7 +25,7 @@ initdb_locale = node['postgresql']['initdb_locale']
 # Otherwise the templates fail.
 
 group "postgres" do
-  gid 26
+  gid node['postgresql']['gid']
 end
 
 user "postgres" do
@@ -34,7 +34,7 @@ user "postgres" do
   home "/var/lib/pgsql"
   gid "postgres"
   system true
-  uid 26
+  uid node['postgresql']['uid']
   supports :manage_home => false
 end
 


### PR DESCRIPTION
For RHEL systems, where uid/gid 26 already used by another applications, uid/gid configuration available from attributes
