### PR TITLE
restart postgres service immediately on config change

### DIFF
--- a/recipes/server_conf.rb
+++ b/recipes/server_conf.rb
@@ -22,7 +22,7 @@ template "#{node['postgresql']['dir']}/postgresql.conf" do
   owner "postgres"
   group "postgres"
   mode 0600
-  notifies change_notify, 'service[postgresql]', :delayed
+  notifies change_notify, 'service[postgresql]', :immediately
 end
 
 template "#{node['postgresql']['dir']}/pg_hba.conf" do
@@ -30,5 +30,5 @@ template "#{node['postgresql']['dir']}/pg_hba.conf" do
   owner "postgres"
   group "postgres"
   mode 00600
-  notifies change_notify, 'service[postgresql]', :delayed
+  notifies change_notify, 'service[postgresql]', :immediately
 end


### PR DESCRIPTION
LWRP's which attempt to connect to the running instance of PostgreSQL during a Chef converge, like the database cookbook's, cannot access the running instance if the listen address or access control rules are modified during the Chef run.

This is because Postgres is installed and started, then configured with the new listen address. When the attribute for the listen address is passed to a resource attempting to connect to the database the connection fails with an error output like below:

```
[2015-05-06T18:19:58+00:00] ERROR: postgresql_database[split-api] (split-api::database line 16) had an error: PG::ConnectionBad: could not connect to server: Connection refused
        Is the server running on host "10.20.1.24" and accepting
 	TCP/IP connections on port 5432?
```

This is because the PostgreSQL configuration files are set to notify the PostgreSQL service to restart with the `:delayed` timer.

This can be worked around by reopening (also known as cloning) the resource by defining your own resource named "postgresql" in your own recipe:

```ruby
include_recipe "postgresql::server"

service "postgresql" do
  subscribes :restart, "template[#{node[:postgresql][:dir]}/pg_hba.conf]", :immediately
  subscribes :restart, "template[#{node[:postgresql][:dir]}/postgresql.conf]", :immediately
end

postgresql_database "my_database" do
  connection(
    host: node[:postgresql][:config][:listen_addresses],
    port: node[:postgresql][:config][:port],
    username: 'postgres',
    password: node[:postgresql][:password][:postgres]
  )
  action :create
end
```

This PR changes the timer to `:immediately` which prevents the usage of the work around above.