### PR TITLE
Amazon linux 2015 pgdg support

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -234,6 +234,10 @@ default['postgresql']['initdb_locale'] = nil
 default['postgresql']['pgdg']['repo_rpm_url'] = {
   "9.3" => {
     "amazon" => {
+      "2015" => {
+        "i386" => "http://yum.postgresql.org/9.3/redhat/rhel-6-i386/pgdg-redhat93-9.3-1.noarch.rpm",
+        "x86_64" => "http://yum.postgresql.org/9.3/redhat/rhel-6-x86_64/pgdg-redhat93-9.3-1.noarch.rpm"
+      },
       "2014" => {
         "i386" => "http://yum.postgresql.org/9.3/redhat/rhel-6-i386/pgdg-redhat93-9.3-1.noarch.rpm",
         "x86_64" => "http://yum.postgresql.org/9.3/redhat/rhel-6-x86_64/pgdg-redhat93-9.3-1.noarch.rpm"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "support@hw-ops.com"
 license           "Apache 2.0"
 description       "Installs and configures postgresql for clients or servers"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "3.4.19"
+version           "3.4.20"
 recipe            "postgresql", "Includes postgresql::client"
 recipe            "postgresql::ruby", "Installs pg gem for Ruby bindings"
 recipe            "postgresql::client", "Installs postgresql client package(s)"


### PR DESCRIPTION
The recipe yum_pgdg_postgresql throws an error "key 2015 not exists" when trying to converge in a ec2 amazon linux 2015 instance, as there is no definition for the rpm url of pgdg yum repositoriy.  