### PR TITLE
Missing attribute in docs for yum_pgdg_postgresql

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ values that will need to have embedded version numbers. For example:
     node['postgresql']['enable_pgdg_yum'] = true
     node['postgresql']['version'] = "9.2"
     node['postgresql']['dir'] = "/var/lib/pgsql/9.2/data"
+    node['postgresql']['config']['data_directory'] = node['postgresql']['dir']
     node['postgresql']['client']['packages'] = ["postgresql92", "postgresql92-devel"]
     node['postgresql']['server']['packages'] = ["postgresql92-server"]
     node['postgresql']['server']['service_name'] = "postgresql-9.2"


### PR DESCRIPTION
If `node['postgresql']['config']['data_directory']` is not defined by the user when installing a version of postgres from yum_pgdg_postgresql then there will be a mismatch between the location of the data directory, and its configured value.