### PR TITLE
node.save could better not be run on every chef 

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -41,8 +41,10 @@ else
   # login for user 'postgres'). However, a random password wouldn't be
   # useful if it weren't saved as clear text in Chef Server for later
   # retrieval.
-  node.set_unless['postgresql']['password']['postgres'] = secure_password
-  node.save
+  unless node.key?('postgresql') && node['postgresql'].key?('password') && node['postgresql']['password'].key?('postgres')
+    node.set_unless['postgresql']['password']['postgres'] = secure_password
+    node.save
+  end
 end
 
 # Include the right "family" recipe for installing the server


### PR DESCRIPTION
node.save are costly and could better not be run on every chef run since it causes node.default attributes stored to the node objects to differ during a chef run and when the node finally saves.

In other words, in-between node.save calls will cause attribute defaults set from subsequent cookbook recipes to be removed from the object, until the chef-run is complete and saved again.

In a scenario we are running this causes problems. Hope this can be merged.

