### PR TITLE
Release 3.4.19

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -132,3 +132,44 @@ suites:
       version: "9.3"
       client:
         packages: ["postgresql93", "postgresql93-devel"]
+
+- name: apt-pgdg-server-pg_stat_statements
+  run_list:
+  - recipe[minitest-handler]
+  - recipe[postgresql::ruby]
+  - recipe[postgresql::contrib]
+  excludes: ["centos-5.9", "centos-6.4"]
+  attributes:
+    postgresql:
+      enable_pgdg_apt: true
+      version: "9.3"
+      password:
+        postgres: "iloverandompasswordsbutthiswilldo"
+      config:
+        shared_preload_libraries: "pg_stat_statements"
+        ssl_cert_file: "/etc/ssl/certs/ssl-cert-snakeoil.pem"
+        ssl_key_file: "/etc/ssl/private/ssl-cert-snakeoil.key"
+      contrib:
+        extensions:
+          - pg_stat_statements
+
+- name: yum-pgdg-server-pg_stat_statements
+  run_list:
+  - recipe[minitest-handler]
+  - recipe[postgresql::ruby]
+  - recipe[postgresql::contrib]
+  excludes: ["ubuntu-10.04", "ubuntu-12.04", "debian-7.1.0"]
+  attributes:
+    postgresql:
+      enable_pgdg_yum: true
+      version: "9.3"
+      server:
+        packages: ["postgresql93-server"]
+        service_name: "postgresql-9.3"
+      password:
+        postgres: "iloverandompasswordsbutthiswilldo"
+      config:
+        shared_preload_libraries: "pg_stat_statements"
+      contrib:
+        extensions:
+          - pg_stat_statements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@ postgresql Cookbook CHANGELOG
 =============================
 This file is used to list changes made in each version of the postgresql cookbook.
 
+v3.4.19
+-------
+- node.save could better not be run on every chef run since it causes node.default attributes stored to the node objects to differ during a chef run and when
+- Missing attribute in docs for yum_pgdg_postgresql
+- restart postgres service immediately on config change
+- Run restart command right away on the postgresql service.
+- Add kitchen test for shared_preload_libraries & extension setup.
+- Fix install order of contrib packages to fix pg_stat_statements issues.
+- Add Debian Jessie to whitelist for apt.postgresql.org repo
+- Install version 9.4 on Debian Jessie
+- add amazon 2015
+- add rhel7 support
+
 v3.4.18
 ------
 - Revert changes from #201 with the intention of revisiting these changes as part of the next major version release.

--- a/README.md
+++ b/README.md
@@ -337,6 +337,10 @@ loads its shared library, which can be done with this node attribute:
 
     node['postgresql']['config']['shared_preload_libraries'] = 'pg_stat_statements'
 
+If using `shared_preload_libraries` in combination with the `contrib` recipe,
+make sure that the `contrib` recipe is called before the `server` recipe (to
+ensure the dependencies are installed and setup in order).
+
 apt\_pgdg\_postgresql
 ----------------------
 

--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ values that will need to have embedded version numbers. For example:
     node['postgresql']['enable_pgdg_yum'] = true
     node['postgresql']['version'] = "9.2"
     node['postgresql']['dir'] = "/var/lib/pgsql/9.2/data"
+    node['postgresql']['config']['data_directory'] = node['postgresql']['dir']
     node['postgresql']['client']['packages'] = ["postgresql92", "postgresql92-devel"]
     node['postgresql']['server']['packages'] = ["postgresql92-server"]
     node['postgresql']['server']['service_name'] = "postgresql-9.2"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -232,6 +232,13 @@ default['postgresql']['initdb_locale'] = nil
 #   node['platform_version']             e.g., "5.7", truncated as "5"
 #   node['kernel']['machine']            e.g., "i386" or "x86_64"
 default['postgresql']['pgdg']['repo_rpm_url'] = {
+  "9.4" => {
+    "redhat" => {
+      "7" => {
+        "x86_64" => "http://yum.postgresql.org/9.4/redhat/rhel-7-x86_64/pgdg-redhat94-9.4-1.noarch.rpm"
+      }
+    }
+  },
   "9.3" => {
     "amazon" => {
       "2014" => {
@@ -257,6 +264,9 @@ default['postgresql']['pgdg']['repo_rpm_url'] = {
       }
     },
     "redhat" => {
+      "7" => {
+         "x86_64" => "http://yum.postgresql.org/9.3/redhat/rhel-7-x86_64/pgdg-redhat93-9.3-1.noarch.rpm"
+      },
       "6" => {
         "i386" => "http://yum.postgresql.org/9.3/redhat/rhel-6-i386/pgdg-redhat93-9.3-1.noarch.rpm",
         "x86_64" => "http://yum.postgresql.org/9.3/redhat/rhel-6-x86_64/pgdg-redhat93-9.3-1.noarch.rpm"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -241,6 +241,10 @@ default['postgresql']['pgdg']['repo_rpm_url'] = {
   },
   "9.3" => {
     "amazon" => {
+      "2015" => {
+        "i386" => "http://yum.postgresql.org/9.3/redhat/rhel-6-i386/pgdg-redhat93-9.3-1.noarch.rpm",
+        "x86_64" => "http://yum.postgresql.org/9.3/redhat/rhel-6-x86_64/pgdg-redhat93-9.3-1.noarch.rpm"
+      },
       "2014" => {
         "i386" => "http://yum.postgresql.org/9.3/redhat/rhel-6-i386/pgdg-redhat93-9.3-1.noarch.rpm",
         "x86_64" => "http://yum.postgresql.org/9.3/redhat/rhel-6-x86_64/pgdg-redhat93-9.3-1.noarch.rpm"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,8 +30,10 @@ when "debian"
     default['postgresql']['version'] = "8.3"
   when node['platform_version'].to_f < 7.0 # All 6.X
     default['postgresql']['version'] = "8.4"
-  else
+  when node['platform_version'].to_f < 8.0 # All 7.X
     default['postgresql']['version'] = "9.1"
+  else
+    default['postgresql']['version'] = "9.4"
   end
 
   default['postgresql']['dir'] = "/etc/postgresql/#{node['postgresql']['version']}/main"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "support@hw-ops.com"
 license           "Apache 2.0"
 description       "Installs and configures postgresql for clients or servers"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "3.4.18"
+version           "3.4.19"
 recipe            "postgresql", "Includes postgresql::client"
 recipe            "postgresql::ruby", "Installs pg gem for Ruby bindings"
 recipe            "postgresql::client", "Installs postgresql client package(s)"

--- a/recipes/apt_pgdg_postgresql.rb
+++ b/recipes/apt_pgdg_postgresql.rb
@@ -1,4 +1,4 @@
-if not %w(squeeze wheezy sid lucid precise saucy trusty utopic).include? node['postgresql']['pgdg']['release_apt_codename']
+if not %w(jessie squeeze wheezy sid lucid precise saucy trusty utopic).include? node['postgresql']['pgdg']['release_apt_codename']
   raise "Not supported release by PGDG apt repository"
 end
 

--- a/recipes/contrib.rb
+++ b/recipes/contrib.rb
@@ -15,8 +15,6 @@
 # limitations under the License.
 #
 
-include_recipe "postgresql::server"
-
 db_name = node['postgresql']['database_name']
 
 # Install the PostgreSQL contrib package(s) from the distribution,
@@ -26,6 +24,8 @@ node['postgresql']['contrib']['packages'].each do |pg_pack|
   package pg_pack
 
 end
+
+include_recipe "postgresql::server"
 
 # Install PostgreSQL contrib extentions into the database, as specified by the
 # node attribute node['postgresql']['database_name'].

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -41,8 +41,10 @@ else
   # login for user 'postgres'). However, a random password wouldn't be
   # useful if it weren't saved as clear text in Chef Server for later
   # retrieval.
-  node.set_unless['postgresql']['password']['postgres'] = secure_password
-  node.save
+  unless node.key?('postgresql') && node['postgresql'].key?('password') && node['postgresql']['password'].key?('postgres')
+    node.set_unless['postgresql']['password']['postgres'] = secure_password
+    node.save
+  end
 end
 
 # Include the right "family" recipe for installing the server

--- a/recipes/server_conf.rb
+++ b/recipes/server_conf.rb
@@ -22,7 +22,7 @@ template "#{node['postgresql']['dir']}/postgresql.conf" do
   owner "postgres"
   group "postgres"
   mode 0600
-  notifies change_notify, 'service[postgresql]', :delayed
+  notifies change_notify, 'service[postgresql]', :immediately
 end
 
 template "#{node['postgresql']['dir']}/pg_hba.conf" do
@@ -30,5 +30,5 @@ template "#{node['postgresql']['dir']}/pg_hba.conf" do
   owner "postgres"
   group "postgres"
   mode 00600
-  notifies change_notify, 'service[postgresql]', :delayed
+  notifies change_notify, 'service[postgresql]', :immediately
 end

--- a/recipes/server_debian.rb
+++ b/recipes/server_debian.rb
@@ -28,7 +28,7 @@ include_recipe "postgresql::server_conf"
 service "postgresql" do
   service_name node['postgresql']['server']['service_name']
   supports :restart => true, :status => true, :reload => true
-  action [:enable, :start]
+  action [:enable, :start, :restart]
 end
 
 execute 'Set locale and Create cluster' do

--- a/recipes/server_redhat.rb
+++ b/recipes/server_redhat.rb
@@ -77,7 +77,13 @@ if platform_family?("fedora") and node['platform_version'].to_i >= 16
     not_if { ::FileTest.exist?(File.join(dir, "PG_VERSION")) }
   end
 
-else !platform_family?("suse") 
+elsif platform?("redhat") and node['platform_version'].to_i >= 7
+
+  execute "postgresql#{node['postgresql']['version'].split('.').join}-setup initdb #{svc_name}" do
+    not_if { ::FileTest.exist?(File.join(dir, "PG_VERSION")) }
+  end
+
+else !platform_family?("suse")
 
   execute "/sbin/service #{svc_name} initdb #{initdb_locale}" do
     not_if { ::FileTest.exist?(File.join(dir, "PG_VERSION")) }


### PR DESCRIPTION
- node.save could better not be run on every chef run since it causes node.default attributes stored to the node objects to differ during a chef run and when
- Missing attribute in docs for yum_pgdg_postgresql
- restart postgres service immediately on config change
- Run restart command right away on the postgresql service.
- Add kitchen test for shared_preload_libraries & extension setup.
- Fix install order of contrib packages to fix pg_stat_statements issues.
- Add Debian Jessie to whitelist for apt.postgresql.org repo
- Install version 9.4 on Debian Jessie
- add amazon 2015
- add rhel7 support