### PR TITLE
Revert #251, release as 3.4.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@ postgresql Cookbook CHANGELOG
 =============================
 This file is used to list changes made in each version of the postgresql cookbook.
 
-v3.4.19
+v3.4.20
+-------
+- Revert [#251](https://github.com/hw-cookbooks/postgresql/pull/251), a change which caused the postgresql service to restart every Chef run.
+
+v3.4.19 [YANKED]
 -------
 - node.save could better not be run on every chef run since it causes node.default attributes stored to the node objects to differ during a chef run and when
 - Missing attribute in docs for yum_pgdg_postgresql

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "support@hw-ops.com"
 license           "Apache 2.0"
 description       "Installs and configures postgresql for clients or servers"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "3.4.19"
+version           "3.4.20"
 recipe            "postgresql", "Includes postgresql::client"
 recipe            "postgresql::ruby", "Installs pg gem for Ruby bindings"
 recipe            "postgresql::client", "Installs postgresql client package(s)"

--- a/recipes/server_debian.rb
+++ b/recipes/server_debian.rb
@@ -28,7 +28,7 @@ include_recipe "postgresql::server_conf"
 service "postgresql" do
   service_name node['postgresql']['server']['service_name']
   supports :restart => true, :status => true, :reload => true
-  action [:enable, :start, :restart]
+  action [:enable, :start]
 end
 
 execute 'Set locale and Create cluster' do


### PR DESCRIPTION
As described in #266, the changes in #251 cause postgresql service to restart every Chef run. If you need this behavior, please consider using a wrapper cookbook to modify this service resource's actions.