### PR TITLE
Add default package names for OpenSUSE 

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -24,6 +24,16 @@ platforms:
 
 - name: centos-5.10
 
+- name: opscode-opensuse-13.2
+  driver:
+    box: gsaslis/opensuse-13.2
+    box_url: https://atlas.hashicorp.com/gsaslis/boxes/opensuse-13.2
+
+- name: opscode-opensuse-13.1
+  driver:
+    box: opensuse-13.1
+    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_opensuse-13.1-x86_64_chef-provisionerless.box
+
 suites:
 - name: default
   run_list:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -125,7 +125,7 @@ when "redhat", "centos", "scientific", "oracle"
     default['postgresql']['server']['service_name'] = "postgresql"
   end
 
-when "suse"
+when "opensuse"
 
   if node['platform_version'].to_f == 13.2
     default['postgresql']['version'] = '9.3'
@@ -137,7 +137,13 @@ when "suse"
     default['postgresql']['client']['packages'] = ['postgresql92', 'postgresql92-devel']
     default['postgresql']['server']['packages'] = ['postgresql92-server']
     default['postgresql']['contrib']['packages'] = ['postgresql92-contrib']
-  elsif node['platform_version'].to_f <= 11.1
+  end
+
+  default['postgresql']['dir'] = "/var/lib/pgsql/data"
+  default['postgresql']['server']['service_name'] = "postgresql"
+
+when "suse"
+    if node['platform_version'].to_f <= 11.1
     default['postgresql']['version'] = "8.3"
     default['postgresql']['client']['packages'] = ['postgresql', 'rubygem-pg']
     default['postgresql']['server']['packages'] = ['postgresql-server']

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -127,7 +127,17 @@ when "redhat", "centos", "scientific", "oracle"
 
 when "suse"
 
-  if node['platform_version'].to_f <= 11.1
+  if node['platform_version'].to_f == 13.2
+    default['postgresql']['version'] = '9.3'
+    default['postgresql']['client']['packages'] = ['postgresql93', 'postgresql93-devel']
+    default['postgresql']['server']['packages'] = ['postgresql93-server']
+    default['postgresql']['contrib']['packages'] = ['postgresql93-contrib']
+  elsif node['platform_version'].to_f == 13.1
+    default['postgresql']['version'] = '9.2'
+    default['postgresql']['client']['packages'] = ['postgresql92', 'postgresql92-devel']
+    default['postgresql']['server']['packages'] = ['postgresql92-server']
+    default['postgresql']['contrib']['packages'] = ['postgresql92-contrib']
+  elsif node['platform_version'].to_f <= 11.1
     default['postgresql']['version'] = "8.3"
     default['postgresql']['client']['packages'] = ['postgresql', 'rubygem-pg']
     default['postgresql']['server']['packages'] = ['postgresql-server']

--- a/metadata.rb
+++ b/metadata.rb
@@ -15,7 +15,7 @@ recipe            "postgresql::server_debian", "Installs postgresql server packa
 
 supports "ubuntu", "< 14.10"
 
-%w{debian fedora suse amazon}.each do |os|
+%w{debian fedora suse opensuse amazon}.each do |os|
   supports os
 end
 

--- a/test/unit/default_spec.rb
+++ b/test/unit/default_spec.rb
@@ -13,6 +13,9 @@ describe 'postgresql::default' do
      },
     'debian' => {
        'versions' => ['7.6']
+     },
+    'opensuse' => {
+       'versions' => ['13.1', '13.2']
      }
   }
 

--- a/test/unit/opensuse_131_server_spec.rb
+++ b/test/unit/opensuse_131_server_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+
+describe 'opensuse::postgresql::server' do
+  let(:chef_application) do
+    double('Chef::Application',fatal!:false);
+  end
+  let(:chef_run) do
+    runner = ChefSpec::SoloRunner.new(
+      platform: 'opensuse', version: '13.1'
+    ) do |node|
+      node.automatic['memory']['total'] = '2048kB'
+      node.automatic['ipaddress'] = '1.1.1.1'
+      node.set['postgresql']['version'] = '9.2'
+      node.set['postgresql']['password']['postgres'] = 'password'
+      node.set['postgresql']['dir'] = '/var/lib/pgsql/data'
+      node.set['postgresql']['conf_dir'] = '/etc/sysconfig/pgsql'
+      node.set['postgresql']['initdb_locale'] = 'UTF-8'
+    end
+    runner.converge('postgresql::server')
+  end
+  before do
+    stub_const('Chef::Application',chef_application)
+    allow(File).to receive(:directory?).and_call_original
+    allow(File).to receive(:directory?).with('/etc/sysconfig/pgsql').and_return(false)
+    stub_command("ls /var/lib/pgsql/data/recovery.conf").and_return(false)
+  end
+
+  it 'Install postgresql 9.2' do
+    expect(chef_run).to install_package('postgresql92-server')
+  end
+
+  it 'Install postgresql 9.2 client' do
+    expect(chef_run).to install_package('postgresql92')
+  end
+
+  it 'Install postgresql 9.2 dev files' do
+    expect(chef_run).to install_package('postgresql92-devel')
+  end
+
+  it 'Enable and start service postgresql' do
+    expect(chef_run).to enable_service('postgresql')
+    expect(chef_run).to start_service('postgresql')
+  end
+
+  it 'Create configuration files' do
+    expect(chef_run).to create_template('/var/lib/pgsql/data/postgresql.conf')
+    expect(chef_run).to create_template('/var/lib/pgsql/data/pg_hba.conf')
+  end
+
+  it 'Assign Postgres Password' do
+    expect(chef_run).to run_bash('assign-postgres-password')
+  end
+
+  context 'when running as a standby host' do
+    it 'does not assign the Postgres password' do
+      stub_command("ls /var/lib/pgsql/main/recovery.conf").and_return(false)
+      expect(chef_run).to_not run_bash('assign_postgres_password')
+    end
+  end
+
+  it 'Launch Cluster Creation' do
+    expect(chef_run).to run_execute('/sbin/service postgresql initdb UTF-8')
+  end
+
+  context 'Directory /etc/sysconfig/pgsql exist' do
+    before do
+      allow(File).to receive(:directory?).and_call_original
+      allow(File).to receive(:directory?).with('/etc/sysconfig/pgsql').and_return(true)
+    end
+
+    it 'Don\'t launch Cluster Creation' do
+      expect(chef_run).to_not run_execute('Set locale and Create cluster')
+    end
+  end
+end

--- a/test/unit/opensuse_132_server_spec.rb
+++ b/test/unit/opensuse_132_server_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+
+describe 'opensuse::postgresql::server' do
+  let(:chef_application) do
+    double('Chef::Application',fatal!:false);
+  end
+  let(:chef_run) do
+    runner = ChefSpec::SoloRunner.new(
+      platform: 'opensuse', version: '13.2'
+    ) do |node|
+      node.automatic['memory']['total'] = '2048kB'
+      node.automatic['ipaddress'] = '1.1.1.1'
+      node.set['postgresql']['version'] = '9.3'
+      node.set['postgresql']['password']['postgres'] = 'password'
+      node.set['postgresql']['dir'] = '/var/lib/pgsql/data'
+      node.set['postgresql']['conf_dir'] = '/etc/sysconfig/pgsql'
+      node.set['postgresql']['initdb_locale'] = 'UTF-8'
+    end
+    runner.converge('postgresql::server')
+  end
+  before do
+    stub_const('Chef::Application',chef_application)
+    allow(File).to receive(:directory?).and_call_original
+    allow(File).to receive(:directory?).with('/etc/sysconfig/pgsql').and_return(false)
+    stub_command("ls /var/lib/pgsql/data/recovery.conf").and_return(false)
+  end
+
+  it 'Install postgresql 9.3' do
+    expect(chef_run).to install_package('postgresql93-server')
+  end
+
+  it 'Install postgresql 9.3 client' do
+    expect(chef_run).to install_package('postgresql93')
+  end
+
+  it 'Install postgresql 9.3 dev files' do
+    expect(chef_run).to install_package('postgresql93-devel')
+  end
+
+  it 'Enable and start service postgresql' do
+    expect(chef_run).to enable_service('postgresql')
+    expect(chef_run).to start_service('postgresql')
+  end
+
+  it 'Create configuration files' do
+    expect(chef_run).to create_template('/var/lib/pgsql/data/postgresql.conf')
+    expect(chef_run).to create_template('/var/lib/pgsql/data/pg_hba.conf')
+  end
+
+  it 'Assign Postgres Password' do
+    expect(chef_run).to run_bash('assign-postgres-password')
+  end
+
+  context 'when running as a standby host' do
+    it 'does not assign the Postgres password' do
+      stub_command("ls /var/lib/pgsql/main/recovery.conf").and_return(false)
+      expect(chef_run).to_not run_bash('assign_postgres_password')
+    end
+  end
+
+  it 'Launch Cluster Creation' do
+    expect(chef_run).to run_execute('/sbin/service postgresql initdb UTF-8')
+  end
+
+  context 'Directory /etc/sysconfig/pgsql exist' do
+    before do
+      allow(File).to receive(:directory?).and_call_original
+      allow(File).to receive(:directory?).with('/etc/sysconfig/pgsql').and_return(true)
+    end
+
+    it 'Don\'t launch Cluster Creation' do
+      expect(chef_run).to_not run_execute('Set locale and Create cluster')
+    end
+  end
+end

--- a/test/unit/server_spec.rb
+++ b/test/unit/server_spec.rb
@@ -13,7 +13,10 @@ describe 'postgresql::server' do
      },
     'debian' => {
        'versions' => ['7.6']
-     }
+     },
+    'opensuse' => {
+      'versions' => ['13.1', '13.2']
+    }
   }
 
   platforms.each do |platform, config|


### PR DESCRIPTION
add package names and corresponding platforms to test kitchen, to fix issue #271 

Test kitchen tests now pass on these 2 platforms (opensuse 13.1 and 13.2)