### PR TITLE
openssl secure password generation issue

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -42,7 +42,7 @@ else
   # useful if it weren't saved as clear text in Chef Server for later
   # retrieval.
   unless node.key?('postgresql') && node['postgresql'].key?('password') && node['postgresql']['password'].key?('postgres')
-    node.set_unless['postgresql']['password']['postgres'] = random_password
+    node.set_unless['postgresql']['password']['postgres'] = random_password(length: 20, mode: :base64)
     node.save
   end
 end

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 
-i#::Chef::Recipe.send(:include, Opscode::OpenSSL::Password)
 ::Chef::Recipe.send(:include, OpenSSLCookbook::RandomPassword)
 
 include_recipe "postgresql::client"

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -15,7 +15,8 @@
 # limitations under the License.
 #
 
-::Chef::Recipe.send(:include, Opscode::OpenSSL::Password)
+i#::Chef::Recipe.send(:include, Opscode::OpenSSL::Password)
+::Chef::Recipe.send(:include, OpenSSLCookbook::RandomPassword)
 
 include_recipe "postgresql::client"
 
@@ -42,7 +43,7 @@ else
   # useful if it weren't saved as clear text in Chef Server for later
   # retrieval.
   unless node.key?('postgresql') && node['postgresql'].key?('password') && node['postgresql']['password'].key?('postgres')
-    node.set_unless['postgresql']['password']['postgres'] = secure_password
+    node.set_unless['postgresql']['password']['postgres'] = random_password
     node.save
   end
 end


### PR DESCRIPTION
I noticed in the README that the OpenSSL call to generate a secure password for the postgresql database in this cookbook was broken. I think this may fix it. The server recipe seemed to be using an outdated feature that will go away with a future release of the openssl cookbook. Please feel free to test and verify this method. Thanks.  Best Regards, GitBytes (Ian)