### PR TITLE
Postgresql YUM pgdg only has fedora and redhat platform.  Enable yum …

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -357,7 +357,7 @@ end
 def pgdgrepo_rpm_info
   repo_rpm_url = node['postgresql']['pgdg']['repo_rpm_url'].
     fetch(node['postgresql']['version']).            # e.g., fetch for "9.1"
-    fetch(node['platform']).                         # e.g., fetch for "centos"
+    fetch((node['platform'].eql? "centos" )? "redhat" : node['platform']).                         # e.g., fetch for "centos"
     fetch(node['platform_version'].to_f.to_i.to_s).  # e.g., fetch for "5" (truncated "5.7")
     fetch(node['kernel']['machine'])                 # e.g., fetch for "i386" or "x86_64"
 

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -357,7 +357,7 @@ end
 def pgdgrepo_rpm_info
   repo_rpm_url = node['postgresql']['pgdg']['repo_rpm_url'].
     fetch(node['postgresql']['version']).            # e.g., fetch for "9.1"
-    fetch((node['platform'].eql? "centos" )? "redhat" : node['platform']).                         # e.g., fetch for "centos"
+    fetch(node['postgresql']['enable_pgdg_yum'] ? ((node['platform'].eql? "centos" )? "redhat" : node['platform']) : node['platform']).                         # e.g., fetch for "centos"
     fetch(node['platform_version'].to_f.to_i.to_s).  # e.g., fetch for "5" (truncated "5.7")
     fetch(node['kernel']['machine'])                 # e.g., fetch for "i386" or "x86_64"
 

--- a/recipes/server_redhat.rb
+++ b/recipes/server_redhat.rb
@@ -77,11 +77,18 @@ if platform_family?("fedora") and node['platform_version'].to_i >= 16
     not_if { ::FileTest.exist?(File.join(dir, "PG_VERSION")) }
   end
 
-elsif platform?("redhat") and node['platform_version'].to_i >= 7
+elsif (platform?("redhat") || platform?("centos")) and node['platform_version'].to_i >= 7
 
-  execute "postgresql#{node['postgresql']['version'].split('.').join}-setup initdb #{svc_name}" do
-    not_if { ::FileTest.exist?(File.join(dir, "PG_VERSION")) }
+  if node['postgresql']['enable_pgdg_yum']
+    execute "/usr/pgsql-#{node['postgresql']['version']}/bin/postgresql#{node['postgresql']['version'].split('.').join}-setup initdb #{svc_name}" do
+      not_if { ::FileTest.exist?(File.join(dir, "PG_VERSION")) }
+    end
+  else
+    execute "postgresql#{node['postgresql']['version'].split('.').join}-setup initdb #{svc_name}" do
+      not_if { ::FileTest.exist?(File.join(dir, "PG_VERSION")) }
+    end
   end
+
 
 else !platform_family?("suse")
 


### PR DESCRIPTION
When using this cookbook with yum pgdg enable on Centos, this will break as Postgresql yum pgdg only has redhat and fedora.  Running this on Centos will get KeyError.  Force to fetch "redhat" instead of "centos" will fix this issue