### PR TITLE
Use more optimistic openssl version constraint.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -25,4 +25,4 @@ end
 
 depends "apt", ">= 1.9.0"
 depends "build-essential"
-depends "openssl", "~> 4.0.0"
+depends "openssl", "~> 4.0"


### PR DESCRIPTION
The openssl cookbook was previously pinned to version 4.0.x when they reverted a breaking change in release 4.0.0. Its newest version is 4.3.2 and brings some cool features. Therefore I set a more optimistic version constraint. 

This fixes #278.