### PR TITLE
Fixed issue 248. execute call was passing in more than MAJOR and MINO…

### DIFF
--- a/recipes/server_conf.rb
+++ b/recipes/server_conf.rb
@@ -17,8 +17,17 @@
 
 change_notify = node['postgresql']['server']['config_change_notify']
 
-
+# Create the data directory
 directory node['postgresql']['config']['data_directory'] do
+	recursive true
+	owner "postgres"
+	group "postgres"
+	mode 00700
+	action :create
+end
+
+# Create the config directory
+directory node['postgresql']['dir'] do
 	recursive true
 	owner "postgres"
 	group "postgres"

--- a/recipes/server_conf.rb
+++ b/recipes/server_conf.rb
@@ -17,6 +17,15 @@
 
 change_notify = node['postgresql']['server']['config_change_notify']
 
+
+directory node['postgresql']['config']['data_directory'] do
+	recursive true
+	owner "postgres"
+	group "postgres"
+	mode 00750
+	action :create
+end
+
 template "#{node['postgresql']['dir']}/postgresql.conf" do
   source "postgresql.conf.erb"
   owner "postgres"

--- a/recipes/server_conf.rb
+++ b/recipes/server_conf.rb
@@ -22,7 +22,7 @@ directory node['postgresql']['config']['data_directory'] do
 	recursive true
 	owner "postgres"
 	group "postgres"
-	mode 00750
+	mode 00700
 	action :create
 end
 

--- a/recipes/server_debian.rb
+++ b/recipes/server_debian.rb
@@ -36,5 +36,5 @@ two_digit_version = node['postgresql']['version'].split('.')[0..1].join('.')
 execute 'Set locale and Create cluster' do
   command "export LC_ALL=C; /usr/bin/pg_createcluster --start --datadir='#{node['postgresql']['config']['data_directory']}' #{two_digit_version} main"
   action :run
-  not_if { ::File.directory?('/etc/postgresql/' + two_digit_version + '/main') }
+  not_if { ::File.directory?(node['postgresql']['config']['data_directory'] + '/PG_VERSION') }
 end

--- a/recipes/server_debian.rb
+++ b/recipes/server_debian.rb
@@ -32,7 +32,7 @@ service "postgresql" do
 end
 
 execute 'Set locale and Create cluster' do
-  command 'export LC_ALL=C; /usr/bin/pg_createcluster --start ' + node['postgresql']['version'] + ' main'
+  command 'export LC_ALL=C; /usr/bin/pg_createcluster --start ' + node['postgresql']['version'].split('.')[0..1].join('.') + ' main'
   action :run
   not_if { ::File.directory?('/etc/postgresql/' + node['postgresql']['version'] + '/main') }
 end

--- a/recipes/server_debian.rb
+++ b/recipes/server_debian.rb
@@ -34,7 +34,7 @@ end
 two_digit_version = node['postgresql']['version'].split('.')[0..1].join('.')
 
 execute 'Set locale and Create cluster' do
-  command 'export LC_ALL=C; /usr/bin/pg_createcluster --start ' + two_digit_version + ' main'
+  command "export LC_ALL=C; /usr/bin/pg_createcluster --start --datadir='#{node['postgresql']['config']['data_directory']}' #{two_digit_version} main"
   action :run
   not_if { ::File.directory?('/etc/postgresql/' + two_digit_version + '/main') }
 end

--- a/recipes/server_debian.rb
+++ b/recipes/server_debian.rb
@@ -23,21 +23,34 @@ node['postgresql']['server']['packages'].each do |pg_pack|
 
 end
 
-include_recipe "postgresql::server_conf"
 
 two_digit_version = node['postgresql']['version'].split('.')[0..1].join('.')
 
-# So... you probably want to create the DB cluster BEFORE you start it... Juuuust a thought
+# Create the service, enable it, stop it
+service "postgresql" do
+  service_name node['postgresql']['server']['service_name']
+  supports :restart => true, :status => true, :reload => true
+  action [:enable,:stop]
+end
+
+execute "Drop the default cluster" do
+	command "pg_dropcluster #{two_digit_version} main"
+	only_if { `pg_lsclusters | awk -v ver=#{two_digit_version} -v name=main 'NR>1 { if(ver==$1 && name==$2) { print $6 } }'`.chomp.eql?('/var/lib/postgresql/9.1/main') }
+	action :run
+end
+
+include_recipe "postgresql::server_conf"
+
+# Create the cluster
 execute 'Set locale and Create cluster' do
   command "export LC_ALL=C; /usr/bin/pg_createcluster --datadir='#{node['postgresql']['config']['data_directory']}' #{two_digit_version} main"
   action :run
   not_if { ::File.directory?(node['postgresql']['config']['data_directory'] + '/PG_VERSION') }
 end
 
-# Create the service, enable it, start it (after the cluster is configured)
+# Start the server again
 service "postgresql" do
   service_name node['postgresql']['server']['service_name']
-  supports :restart => true, :status => true, :reload => true
-  action [:enable, :start]
+  action [:start]
 end
 

--- a/recipes/server_debian.rb
+++ b/recipes/server_debian.rb
@@ -31,8 +31,10 @@ service "postgresql" do
   action [:enable, :start]
 end
 
+two_digit_version = node['postgresql']['version'].split('.')[0..1].join('.')
+
 execute 'Set locale and Create cluster' do
-  command 'export LC_ALL=C; /usr/bin/pg_createcluster --start ' + node['postgresql']['version'].split('.')[0..1].join('.') + ' main'
+  command 'export LC_ALL=C; /usr/bin/pg_createcluster --start ' + two_digit_version + ' main'
   action :run
-  not_if { ::File.directory?('/etc/postgresql/' + node['postgresql']['version'] + '/main') }
+  not_if { ::File.directory?('/etc/postgresql/' + two_digit_version + '/main') }
 end


### PR DESCRIPTION
…R version numbers to the pg_createcluster script, causing the version to be read as blank. Parsed the version and stripped off any numbers except the first two.