### PR TITLE
added ability to set locale on pg_createcluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ The following attributes are set based on the platform, see the
   database cluster. If this attribute is not specified, the locale is
   inherited from the environment that initdb runs in. Sometimes you must
   have a system locale that is not what you want for your database cluster,
-  and this attribute addresses that scenario. Valid only for EL-family
-  distros (RedHat/Centos/etc.).
+  and this attribute addresses that scenario. Valid for EL-family
+  distros (RedHat/Centos/etc.) and Debian, Ubuntu.
 
 The following attributes are generated in
 `recipe[postgresql::server]`.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -218,8 +218,6 @@ end
 
 default['postgresql']['enable_pgdg_yum'] = false
 
-default['postgresql']['initdb_locale'] = nil
-
 # The PostgreSQL RPM Building Project built repository RPMs for easy
 # access to the PGDG yum repositories. Links to RPMs for installation
 # on the supported version/platform combinations are listed at

--- a/recipes/server_debian.rb
+++ b/recipes/server_debian.rb
@@ -17,6 +17,8 @@
 
 include_recipe "postgresql::client"
 
+pre_installed = ::File.directory?('/etc/postgresql/' + node['postgresql']['version'] + '/main')
+
 node['postgresql']['server']['packages'].each do |pg_pack|
 
   package pg_pack
@@ -31,8 +33,21 @@ service "postgresql" do
   action [:enable, :start]
 end
 
+# this is required as postgresql-9.3 (and later?) package creates a 'main' cluster for us, giving us
+# no opportunity to set the locale
+execute 'Drop main cluster' do
+  command "/usr/bin/pg_dropcluster --stop #{node['postgresql']['version']} main"
+  action :run
+  not_if pre_installed
+end
+
+initdb_locale = node['postgresql']['initdb_locale']
+
+default_cmd = "export LC_ALL=C; /usr/bin/pg_createcluster --start #{node['postgresql']['version']} main"
+locale_cmd = "/usr/bin/pg_createcluster --locale=#{initdb_locale} --start #{node['postgresql']['version']} main"
+
 execute 'Set locale and Create cluster' do
-  command 'export LC_ALL=C; /usr/bin/pg_createcluster --start ' + node['postgresql']['version'] + ' main'
+  command initdb_locale.nil? ? default_cmd : locale_cmd
   action :run
   not_if { ::File.directory?('/etc/postgresql/' + node['postgresql']['version'] + '/main') }
 end

--- a/recipes/server_debian.rb
+++ b/recipes/server_debian.rb
@@ -25,14 +25,6 @@ node['postgresql']['server']['packages'].each do |pg_pack|
 
 end
 
-include_recipe "postgresql::server_conf"
-
-service "postgresql" do
-  service_name node['postgresql']['server']['service_name']
-  supports :restart => true, :status => true, :reload => true
-  action [:enable, :start]
-end
-
 # this is required as postgresql-9.3 (and later?) package creates a 'main' cluster for us, giving us
 # no opportunity to set the locale
 execute 'Drop main cluster' do
@@ -50,4 +42,12 @@ execute 'Set locale and Create cluster' do
   command initdb_locale.nil? ? default_cmd : locale_cmd
   action :run
   not_if { ::File.directory?('/etc/postgresql/' + node['postgresql']['version'] + '/main') }
+end
+
+include_recipe "postgresql::server_conf"
+
+service "postgresql" do
+  service_name node['postgresql']['server']['service_name']
+  supports :restart => true, :status => true, :reload => true
+  action [:enable, :start]
 end


### PR DESCRIPTION
The postgresql-9.3 package on Ubuntu creates a 'main' cluster.

This pull request allows us to configure the main cluster ourselves, by dropping and re-creating it.
Idempotence is achieved by checking if the 'main' cluster is already installed prior to running the package install.