### PR TITLE
update test-kitchen excludes in suites for specific platforms

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -138,7 +138,7 @@ suites:
   - recipe[minitest-handler]
   - recipe[postgresql::ruby]
   - recipe[postgresql::contrib]
-  excludes: ["centos-5.9", "centos-6.4"]
+  excludes: ["centos-5.10", "centos-6.4", "centos-7.0"]
   attributes:
     postgresql:
       enable_pgdg_apt: true
@@ -158,7 +158,7 @@ suites:
   - recipe[minitest-handler]
   - recipe[postgresql::ruby]
   - recipe[postgresql::contrib]
-  excludes: ["ubuntu-10.04", "ubuntu-12.04", "debian-7.1.0"]
+  excludes: ["ubuntu-10.04", "ubuntu-12.04", "ubuntu-14.04", "debian-7.4"]
   attributes:
     postgresql:
       enable_pgdg_yum: true


### PR DESCRIPTION
This cleans up a few spots where kitchen would list platforms for suites that were not supported by the platform.