### PR TITLE
Add Gem.clear_paths to server minitest so pg gem is loaded correctly

### DIFF
--- a/files/default/tests/minitest/server_test.rb
+++ b/files/default/tests/minitest/server_test.rb
@@ -30,6 +30,7 @@ describe 'postgresql::server' do
   end
 
   it 'can connect to postgresql' do
+    Gem.clear_paths
     require 'pg'
     conn = PG::Connection.new(
                                :host => 'localhost',


### PR DESCRIPTION
Add Gem.clear_paths to server minitest so pg gem is loaded correctly on first converge.

Sometimes kitchen test would fail on first run. The test to connect to database would fail because the pg gem wouldn't be available to the chef run.