### PR TITLE
make sure centos has a chance to initdb

### DIFF
--- a/recipes/server_redhat.rb
+++ b/recipes/server_redhat.rb
@@ -93,7 +93,7 @@ if platform_family?("fedora") and node['platform_version'].to_i >= 16
     not_if { ::FileTest.exist?(File.join(dir, "PG_VERSION")) }
   end
 
-elsif platform?("redhat") and node['platform_version'].to_i >= 7
+elsif ( platform?("redhat") or platform?("centos") ) and node['platform_version'].to_i >= 7
 
   execute "postgresql#{shortver}-setup initdb #{svc_name}" do
     not_if { ::FileTest.exist?(File.join(dir, "PG_VERSION")) }


### PR DESCRIPTION
Previously this would fail to the last elsif block which is not correct. Centos will want to perform the same action as redhat. 