### PR TITLE
Update ca certificates - Update version comparison to configure setup_script

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -133,7 +133,7 @@ when "fedora"
   default['postgresql']['server']['service_name'] = "postgresql"
   default['postgresql']['setup_script'] = "postgresql-setup"
 
-  if node['postgresql']['version'] == '9.3'
+  if node['postgresql']['version'].to_f >= 9.3
     default['postgresql']['setup_script'] = "/usr/pgsql-#{node['postgresql']['version']}/bin/postgresql#{node['postgresql']['version'].split('.').join}-setup"
   end
 
@@ -177,7 +177,7 @@ when "redhat", "centos", "scientific", "oracle"
       default['postgresql']['server']['service_name'] = "postgresql-#{node['postgresql']['version']}"
     end
 
-    if node['postgresql']['version'] == '9.3'
+    if node['postgresql']['version'].to_f >= 9.3
       default['postgresql']['setup_script'] = "/usr/pgsql-#{node['postgresql']['version']}/bin/postgresql#{node['postgresql']['version'].split('.').join}-setup"
     end
   else

--- a/recipes/ca_certificates.rb
+++ b/recipes/ca_certificates.rb
@@ -1,0 +1,6 @@
+# some older linux distributions have expired certificate bundles
+# for pgdg repositories. Upgrading this package before trying to
+# install postgresql is necessary.
+package "ca-certificates" do
+  action :upgrade
+end

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+include_recipe "postgresql::ca_certificates"
+
 if platform_family?('debian') && node['postgresql']['version'].to_f > 9.3
   node.default['postgresql']['enable_pgdg_apt'] = true
 end

--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -35,6 +35,9 @@ rescue LoadError
 
   if node['postgresql']['enable_pgdg_yum']
     repo_rpm_url, repo_rpm_filename, repo_rpm_package = pgdgrepo_rpm_info
+    package "ca-certificates" do
+      action :nothing
+    end.run_action(:upgrade)
     include_recipe "postgresql::yum_pgdg_postgresql"
     resources("remote_file[#{Chef::Config[:file_cache_path]}/#{repo_rpm_filename}]").run_action(:create)
     resources("package[#{repo_rpm_package}]").run_action(:install)

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+include_recipe "postgresql::ca_certificates"
+
 ::Chef::Recipe.send(:include, OpenSSLCookbook::RandomPassword)
 
 include_recipe "postgresql::client"


### PR DESCRIPTION
* Most specifically if you were trying to install Postgresql 9.2 from the pgdg repository it would always fail. This is because the default ca-certificate package version installed on some distributions does not included more recent signing certificates for packages from pgdg.  

* compare version as float and should match anything 9.3 and above