### PR TITLE
Postgresql 3.4.24

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -24,12 +24,12 @@ platforms:
 
 - name: centos-5.10
 
-- name: opscode-opensuse-13.2
+- name: opensuse-13.2
   driver:
     box: gsaslis/opensuse-13.2
     box_url: https://atlas.hashicorp.com/gsaslis/boxes/opensuse-13.2
 
-- name: opscode-opensuse-13.1
+- name: opensuse-13.1
   driver:
     box: opensuse-13.1
     box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_opensuse-13.1-x86_64_chef-provisionerless.box
@@ -53,7 +53,7 @@ suites:
   run_list:
   - recipe[minitest-handler]
   - recipe[postgresql]
-  excludes: ["centos-5.10", "centos-6.4", "centos-7.0"]
+  excludes: ["centos-5.10", "centos-6.4", "centos-7.0", "opensuse-13.1", "opensuse-13.2"]
   attributes:
     postgresql:
       enable_pgdg_apt: true
@@ -63,7 +63,7 @@ suites:
   run_list:
   - recipe[minitest-handler]
   - recipe[postgresql]
-  excludes: ["ubuntu-10.04", "ubuntu-12.04", "ubuntu-14.04", "debian-7.4"]
+  excludes: ["ubuntu-10.04", "ubuntu-12.04", "ubuntu-14.04", "debian-7.4", "opensuse-13.1", "opensuse-13.2"]
   attributes:
     postgresql:
       enable_pgdg_yum: true
@@ -92,7 +92,7 @@ suites:
   - recipe[minitest-handler]
   - recipe[postgresql::ruby]
   - recipe[postgresql::server]
-  excludes: ["centos-5.10", "centos-6.4", "centos-7.0"]
+  excludes: ["centos-5.10", "centos-6.4", "centos-7.0", "opensuse-13.1", "opensuse-13.2"]
   attributes:
     postgresql:
       enable_pgdg_apt: true
@@ -108,7 +108,7 @@ suites:
   - recipe[minitest-handler]
   - recipe[postgresql::ruby]
   - recipe[postgresql::server]
-  excludes: ["ubuntu-10.04", "ubuntu-12.04", "ubuntu-14.04", "debian-7.4"]
+  excludes: ["ubuntu-10.04", "ubuntu-12.04", "ubuntu-14.04", "debian-7.4", "opensuse-13.1", "opensuse-13.2"]
   attributes:
     postgresql:
       enable_pgdg_yum: true
@@ -124,7 +124,7 @@ suites:
   - recipe[minitest-handler]
   - recipe[postgresql]
   - recipe[postgresql::ruby]
-  excludes: ["centos-5.10", "centos-6.4", "centos-7.0"]
+  excludes: ["centos-5.10", "centos-6.4", "centos-7.0", "opensuse-13.1", "opensuse-13.2"]
   attributes:
     postgresql:
       enable_pgdg_apt: true
@@ -135,7 +135,7 @@ suites:
   - recipe[minitest-handler]
   - recipe[postgresql]
   - recipe[postgresql::ruby]
-  excludes: ["ubuntu-10.04", "ubuntu-12.04", "ubuntu-14.04", "debian-7.4"]
+  excludes: ["ubuntu-10.04", "ubuntu-12.04", "ubuntu-14.04", "debian-7.4", "opensuse-13.1", "opensuse-13.2"]
   attributes:
     postgresql:
       enable_pgdg_yum: true
@@ -148,7 +148,7 @@ suites:
   - recipe[minitest-handler]
   - recipe[postgresql::ruby]
   - recipe[postgresql::contrib]
-  excludes: ["centos-5.10", "centos-6.4", "centos-7.0"]
+  excludes: ["centos-5.10", "centos-6.4", "centos-7.0", "opensuse-13.1", "opensuse-13.2"]
   attributes:
     postgresql:
       enable_pgdg_apt: true
@@ -168,7 +168,7 @@ suites:
   - recipe[minitest-handler]
   - recipe[postgresql::ruby]
   - recipe[postgresql::contrib]
-  excludes: ["ubuntu-10.04", "ubuntu-12.04", "ubuntu-14.04", "debian-7.4"]
+  excludes: ["ubuntu-10.04", "ubuntu-12.04", "ubuntu-14.04", "debian-7.4", "opensuse-13.1", "opensuse-13.2"]
   attributes:
     postgresql:
       enable_pgdg_yum: true

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -24,6 +24,16 @@ platforms:
 
 - name: centos-5.10
 
+- name: opscode-opensuse-13.2
+  driver:
+    box: gsaslis/opensuse-13.2
+    box_url: https://atlas.hashicorp.com/gsaslis/boxes/opensuse-13.2
+
+- name: opscode-opensuse-13.1
+  driver:
+    box: opensuse-13.1
+    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_opensuse-13.1-x86_64_chef-provisionerless.box
+
 suites:
 - name: default
   run_list:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@ postgresql Cookbook CHANGELOG
 =============================
 This file is used to list changes made in each version of the postgresql cookbook.
 
+v3.4.24
+-------
+* Corrections to address repositories signed with newer certificates that some distributions have in their default ca-certificates package
+* Updates to more accurately determine distributions service init systems adds better support for systemd systems
+* Correct how version attribute is evaluated in certain places
+* test-kitchen suite configuration corrections
+* Opensuse support
+
 v3.4.23
 -------
 - Skipping 3.4.22 with Develop branch 3.4.23 to return to releasing cookbook from master on even numbers and develop on odd numbers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ postgresql Cookbook CHANGELOG
 =============================
 This file is used to list changes made in each version of the postgresql cookbook.
 
+v3.4.23
+-------
+- Skipping 3.4.22 with Develop branch 3.4.23 to return to releasing cookbook from master on even numbers and develop on odd numbers.
+
 v3.4.21
 -------
 - Use more optimistic openssl version constraint

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -234,7 +234,7 @@ end
 
 default['postgresql']['enable_pgdg_yum'] = false
 
-default['postgresql']['initdb_locale'] = nil
+default['postgresql']['initdb_locale'] = 'UTF-8'
 
 # The PostgreSQL RPM Building Project built repository RPMs for easy
 # access to the PGDG yum repositories. Links to RPMs for installation

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -133,7 +133,7 @@ when "fedora"
   default['postgresql']['server']['service_name'] = "postgresql"
   default['postgresql']['setup_script'] = "postgresql-setup"
 
-  if node['postgresql']['version'] == '9.3'
+  if node['postgresql']['version'].to_f >= 9.3
     default['postgresql']['setup_script'] = "/usr/pgsql-#{node['postgresql']['version']}/bin/postgresql#{node['postgresql']['version'].split('.').join}-setup"
   end
 
@@ -177,7 +177,7 @@ when "redhat", "centos", "scientific", "oracle"
       default['postgresql']['server']['service_name'] = "postgresql-#{node['postgresql']['version']}"
     end
 
-    if node['postgresql']['version'] == '9.3'
+    if node['postgresql']['version'].to_f >= 9.3
       default['postgresql']['setup_script'] = "/usr/pgsql-#{node['postgresql']['version']}/bin/postgresql#{node['postgresql']['version'].split('.').join}-setup"
     end
   else

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -125,9 +125,25 @@ when "redhat", "centos", "scientific", "oracle"
     default['postgresql']['server']['service_name'] = "postgresql"
   end
 
-when "suse"
+when "opensuse"
 
-  if node['platform_version'].to_f <= 11.1
+  if node['platform_version'].to_f == 13.2
+    default['postgresql']['version'] = '9.3'
+    default['postgresql']['client']['packages'] = ['postgresql93', 'postgresql93-devel']
+    default['postgresql']['server']['packages'] = ['postgresql93-server']
+    default['postgresql']['contrib']['packages'] = ['postgresql93-contrib']
+  elsif node['platform_version'].to_f == 13.1
+    default['postgresql']['version'] = '9.2'
+    default['postgresql']['client']['packages'] = ['postgresql92', 'postgresql92-devel']
+    default['postgresql']['server']['packages'] = ['postgresql92-server']
+    default['postgresql']['contrib']['packages'] = ['postgresql92-contrib']
+  end
+
+  default['postgresql']['dir'] = "/var/lib/pgsql/data"
+  default['postgresql']['server']['service_name'] = "postgresql"
+
+when "suse"
+    if node['platform_version'].to_f <= 11.1
     default['postgresql']['version'] = "8.3"
     default['postgresql']['client']['packages'] = ['postgresql', 'rubygem-pg']
     default['postgresql']['server']['packages'] = ['postgresql-server']

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -400,12 +400,12 @@ default['postgresql']['pgdg']['repo_rpm_url'] = {
   "9.2" => {
     "centos" => {
       "6" => {
-        "i386" => "http://yum.postgresql.org/9.2/redhat/rhel-6-i386/pgdg-centos92-9.2-6.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.2/redhat/rhel-6-x86_64/pgdg-centos92-9.2-6.noarch.rpm"
+        "i386" => "http://yum.postgresql.org/9.2/redhat/rhel-6-i386/pgdg-centos92-9.2-7.noarch.rpm",
+        "x86_64" => "http://yum.postgresql.org/9.2/redhat/rhel-6-x86_64/pgdg-centos92-9.2-7.noarch.rpm"
       },
       "5" => {
-        "i386" => "http://yum.postgresql.org/9.2/redhat/rhel-5-i386/pgdg-centos92-9.2-6.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.2/redhat/rhel-5-x86_64/pgdg-centos92-9.2-6.noarch.rpm"
+        "i386" => "http://yum.postgresql.org/9.2/redhat/rhel-5-i386/pgdg-centos92-9.2-7.noarch.rpm",
+        "x86_64" => "http://yum.postgresql.org/9.2/redhat/rhel-5-x86_64/pgdg-centos92-9.2-7.noarch.rpm"
       }
     },
     "redhat" => {

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "support@hw-ops.com"
 license           "Apache 2.0"
 description       "Installs and configures postgresql for clients or servers"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "3.4.23"
+version           "3.4.24"
 recipe            "postgresql", "Includes postgresql::client"
 recipe            "postgresql::ruby", "Installs pg gem for Ruby bindings"
 recipe            "postgresql::client", "Installs postgresql client package(s)"

--- a/metadata.rb
+++ b/metadata.rb
@@ -15,7 +15,7 @@ recipe            "postgresql::server_debian", "Installs postgresql server packa
 
 supports "ubuntu", "< 14.10"
 
-%w{debian fedora suse amazon}.each do |os|
+%w{debian fedora suse opensuse amazon}.each do |os|
   supports os
 end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "support@hw-ops.com"
 license           "Apache 2.0"
 description       "Installs and configures postgresql for clients or servers"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "3.4.21"
+version           "3.4.23"
 recipe            "postgresql", "Includes postgresql::client"
 recipe            "postgresql::ruby", "Installs pg gem for Ruby bindings"
 recipe            "postgresql::client", "Installs postgresql client package(s)"

--- a/recipes/ca_certificates.rb
+++ b/recipes/ca_certificates.rb
@@ -1,0 +1,6 @@
+# some older linux distributions have expired certificate bundles
+# for pgdg repositories. Upgrading this package before trying to
+# install postgresql is necessary.
+package "ca-certificates" do
+  action :upgrade
+end

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+include_recipe "postgresql::ca_certificates"
+
 if platform_family?('debian') && node['postgresql']['version'].to_f > 9.3
   node.default['postgresql']['enable_pgdg_apt'] = true
 end

--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -35,6 +35,9 @@ rescue LoadError
 
   if node['postgresql']['enable_pgdg_yum']
     repo_rpm_url, repo_rpm_filename, repo_rpm_package = pgdgrepo_rpm_info
+    package "ca-certificates" do
+      action :nothing
+    end.run_action(:upgrade)
     include_recipe "postgresql::yum_pgdg_postgresql"
     resources("remote_file[#{Chef::Config[:file_cache_path]}/#{repo_rpm_filename}]").run_action(:create)
     resources("package[#{repo_rpm_package}]").run_action(:install)

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-::Chef::Recipe.send(:include, Opscode::OpenSSL::Password)
+::Chef::Recipe.send(:include, OpenSSLCookbook::RandomPassword)
 
 include_recipe "postgresql::client"
 
@@ -42,7 +42,7 @@ else
   # useful if it weren't saved as clear text in Chef Server for later
   # retrieval.
   unless node.key?('postgresql') && node['postgresql'].key?('password') && node['postgresql']['password'].key?('postgres')
-    node.set_unless['postgresql']['password']['postgres'] = secure_password
+    node.set_unless['postgresql']['password']['postgres'] = random_password(length: 20, mode: :base64)
     node.save
   end
 end

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+include_recipe "postgresql::ca_certificates"
+
 ::Chef::Recipe.send(:include, OpenSSLCookbook::RandomPassword)
 
 include_recipe "postgresql::client"

--- a/recipes/server_redhat.rb
+++ b/recipes/server_redhat.rb
@@ -99,7 +99,7 @@ elsif platform?("redhat") and node['platform_version'].to_i >= 7
     not_if { ::FileTest.exist?(File.join(dir, "PG_VERSION")) }
   end
 
-else !platform_family?("suse")
+elsif !platform_family?("suse")
 
   execute "/sbin/service #{svc_name} initdb #{initdb_locale}" do
     not_if { ::FileTest.exist?(File.join(dir, "PG_VERSION")) }
@@ -107,10 +107,10 @@ else !platform_family?("suse")
 
 end
 
-include_recipe "postgresql::server_conf"
-
 service "postgresql" do
   service_name svc_name
   supports :restart => true, :status => true, :reload => true
   action [:enable, :start]
 end
+
+include_recipe "postgresql::server_conf"

--- a/recipes/server_redhat.rb
+++ b/recipes/server_redhat.rb
@@ -67,11 +67,12 @@ if node['postgresql']['enable_pgdg_yum'] == true
   end
 end
 
-# Starting with Fedora 16, the pgsql sysconfig files are no longer used.
+# Starting with Fedora 16, the pgsql sysconfig files are no longer used,
+# its use is discouraged if using systemd
 # The systemd unit file does not support 'initdb' or 'upgrade' actions.
 # Use the postgresql-setup script instead.
 
-unless platform_family?("fedora") and node['platform_version'].to_i >= 16
+unless node['postgresql']['server']['init_package'] == 'systemd'
 
   directory "/etc/sysconfig/pgsql" do
     mode "0644"
@@ -87,15 +88,9 @@ unless platform_family?("fedora") and node['platform_version'].to_i >= 16
 
 end
 
-if platform_family?("fedora") and node['platform_version'].to_i >= 16
+if node['postgresql']['server']['init_package'] == 'systemd'
 
-  execute "postgresql-setup initdb #{svc_name}" do
-    not_if { ::FileTest.exist?(File.join(dir, "PG_VERSION")) }
-  end
-
-elsif ( platform?("redhat") or platform?("centos") ) and node['platform_version'].to_i >= 7
-
-  execute "postgresql#{shortver}-setup initdb #{svc_name}" do
+  execute "#{node['postgresql']['setup_script']} initdb #{svc_name}" do
     not_if { ::FileTest.exist?(File.join(dir, "PG_VERSION")) }
   end
 

--- a/recipes/server_redhat.rb
+++ b/recipes/server_redhat.rb
@@ -93,7 +93,7 @@ if platform_family?("fedora") and node['platform_version'].to_i >= 16
     not_if { ::FileTest.exist?(File.join(dir, "PG_VERSION")) }
   end
 
-elsif platform?("redhat") and node['platform_version'].to_i >= 7
+elsif ( platform?("redhat") or platform?("centos") ) and node['platform_version'].to_i >= 7
 
   execute "postgresql#{shortver}-setup initdb #{svc_name}" do
     not_if { ::FileTest.exist?(File.join(dir, "PG_VERSION")) }

--- a/test/unit/default_spec.rb
+++ b/test/unit/default_spec.rb
@@ -13,6 +13,9 @@ describe 'postgresql::default' do
      },
     'debian' => {
        'versions' => ['7.6']
+     },
+    'opensuse' => {
+       'versions' => ['13.1', '13.2']
      }
   }
 

--- a/test/unit/opensuse_131_server_spec.rb
+++ b/test/unit/opensuse_131_server_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+
+describe 'opensuse::postgresql::server' do
+  let(:chef_application) do
+    double('Chef::Application',fatal!:false);
+  end
+  let(:chef_run) do
+    runner = ChefSpec::SoloRunner.new(
+      platform: 'opensuse', version: '13.1'
+    ) do |node|
+      node.automatic['memory']['total'] = '2048kB'
+      node.automatic['ipaddress'] = '1.1.1.1'
+      node.set['postgresql']['version'] = '9.2'
+      node.set['postgresql']['password']['postgres'] = 'password'
+      node.set['postgresql']['dir'] = '/var/lib/pgsql/data'
+      node.set['postgresql']['conf_dir'] = '/etc/sysconfig/pgsql'
+      node.set['postgresql']['initdb_locale'] = 'UTF-8'
+    end
+    runner.converge('postgresql::server')
+  end
+  before do
+    stub_const('Chef::Application',chef_application)
+    allow(File).to receive(:directory?).and_call_original
+    allow(File).to receive(:directory?).with('/etc/sysconfig/pgsql').and_return(false)
+    stub_command("ls /var/lib/pgsql/data/recovery.conf").and_return(false)
+  end
+
+  it 'Install postgresql 9.2' do
+    expect(chef_run).to install_package('postgresql92-server')
+  end
+
+  it 'Install postgresql 9.2 client' do
+    expect(chef_run).to install_package('postgresql92')
+  end
+
+  it 'Install postgresql 9.2 dev files' do
+    expect(chef_run).to install_package('postgresql92-devel')
+  end
+
+  it 'Enable and start service postgresql' do
+    expect(chef_run).to enable_service('postgresql')
+    expect(chef_run).to start_service('postgresql')
+  end
+
+  it 'Create configuration files' do
+    expect(chef_run).to create_template('/var/lib/pgsql/data/postgresql.conf')
+    expect(chef_run).to create_template('/var/lib/pgsql/data/pg_hba.conf')
+  end
+
+  it 'Assign Postgres Password' do
+    expect(chef_run).to run_bash('assign-postgres-password')
+  end
+
+  context 'when running as a standby host' do
+    it 'does not assign the Postgres password' do
+      stub_command("ls /var/lib/pgsql/main/recovery.conf").and_return(false)
+      expect(chef_run).to_not run_bash('assign_postgres_password')
+    end
+  end
+
+  it 'Launch Cluster Creation' do
+    expect(chef_run).to run_execute('/sbin/service postgresql initdb UTF-8')
+  end
+
+  context 'Directory /etc/sysconfig/pgsql exist' do
+    before do
+      allow(File).to receive(:directory?).and_call_original
+      allow(File).to receive(:directory?).with('/etc/sysconfig/pgsql').and_return(true)
+    end
+
+    it 'Don\'t launch Cluster Creation' do
+      expect(chef_run).to_not run_execute('Set locale and Create cluster')
+    end
+  end
+end

--- a/test/unit/opensuse_132_server_spec.rb
+++ b/test/unit/opensuse_132_server_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+
+describe 'opensuse::postgresql::server' do
+  let(:chef_application) do
+    double('Chef::Application',fatal!:false);
+  end
+  let(:chef_run) do
+    runner = ChefSpec::SoloRunner.new(
+      platform: 'opensuse', version: '13.2'
+    ) do |node|
+      node.automatic['memory']['total'] = '2048kB'
+      node.automatic['ipaddress'] = '1.1.1.1'
+      node.set['postgresql']['version'] = '9.3'
+      node.set['postgresql']['password']['postgres'] = 'password'
+      node.set['postgresql']['dir'] = '/var/lib/pgsql/data'
+      node.set['postgresql']['conf_dir'] = '/etc/sysconfig/pgsql'
+      node.set['postgresql']['initdb_locale'] = 'UTF-8'
+    end
+    runner.converge('postgresql::server')
+  end
+  before do
+    stub_const('Chef::Application',chef_application)
+    allow(File).to receive(:directory?).and_call_original
+    allow(File).to receive(:directory?).with('/etc/sysconfig/pgsql').and_return(false)
+    stub_command("ls /var/lib/pgsql/data/recovery.conf").and_return(false)
+  end
+
+  it 'Install postgresql 9.3' do
+    expect(chef_run).to install_package('postgresql93-server')
+  end
+
+  it 'Install postgresql 9.3 client' do
+    expect(chef_run).to install_package('postgresql93')
+  end
+
+  it 'Install postgresql 9.3 dev files' do
+    expect(chef_run).to install_package('postgresql93-devel')
+  end
+
+  it 'Enable and start service postgresql' do
+    expect(chef_run).to enable_service('postgresql')
+    expect(chef_run).to start_service('postgresql')
+  end
+
+  it 'Create configuration files' do
+    expect(chef_run).to create_template('/var/lib/pgsql/data/postgresql.conf')
+    expect(chef_run).to create_template('/var/lib/pgsql/data/pg_hba.conf')
+  end
+
+  it 'Assign Postgres Password' do
+    expect(chef_run).to run_bash('assign-postgres-password')
+  end
+
+  context 'when running as a standby host' do
+    it 'does not assign the Postgres password' do
+      stub_command("ls /var/lib/pgsql/main/recovery.conf").and_return(false)
+      expect(chef_run).to_not run_bash('assign_postgres_password')
+    end
+  end
+
+  it 'Launch Cluster Creation' do
+    expect(chef_run).to run_execute('/sbin/service postgresql initdb UTF-8')
+  end
+
+  context 'Directory /etc/sysconfig/pgsql exist' do
+    before do
+      allow(File).to receive(:directory?).and_call_original
+      allow(File).to receive(:directory?).with('/etc/sysconfig/pgsql').and_return(true)
+    end
+
+    it 'Don\'t launch Cluster Creation' do
+      expect(chef_run).to_not run_execute('Set locale and Create cluster')
+    end
+  end
+end

--- a/test/unit/server_spec.rb
+++ b/test/unit/server_spec.rb
@@ -13,7 +13,10 @@ describe 'postgresql::server' do
      },
     'debian' => {
        'versions' => ['7.6']
-     }
+     },
+    'opensuse' => {
+      'versions' => ['13.1', '13.2']
+    }
   }
 
   platforms.each do |platform, config|


### PR DESCRIPTION
* Corrections to address repositories signed with newer certificates that some distributions have in their default ca-certificates package
* Updates to more accurately determine distributions service init systems adds better support for systemd systems
* Correct how version attribute is evaluated in certain places
* test-kitchen suite configuration corrections
* Opensuse support