### PR TITLE
Allow for more successful postgresql version attribute overrides

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -51,7 +51,7 @@ suites:
   attributes:
     postgresql:
       enable_pgdg_apt: true
-      version: "9.3"
+      version: "9.4"
 
 - name: yum-pgdg-client
   run_list:
@@ -61,9 +61,9 @@ suites:
   attributes:
     postgresql:
       enable_pgdg_yum: true
-      version: "9.3"
+      version: "9.4"
       client:
-        packages: ["postgresql93"]
+        packages: ["postgresql94"]
 
 - name: ruby
   run_list:
@@ -73,8 +73,9 @@ suites:
 
 - name: server
   run_list:
-  - recipe[postgresql::ruby]
+  - recipe[apt]
   - recipe[minitest-handler]
+  - recipe[postgresql::ruby]
   - recipe[postgresql::server]
   attributes:
     postgresql:
@@ -90,7 +91,7 @@ suites:
   attributes:
     postgresql:
       enable_pgdg_apt: true
-      version: "9.3"
+      version: "9.4"
       password:
         postgres: "iloverandompasswordsbutthiswilldo"
       config:
@@ -102,7 +103,7 @@ suites:
   - recipe[minitest-handler]
   - recipe[postgresql::ruby]
   - recipe[postgresql::server]
-  excludes: ["ubuntu-12.04", "ubuntu-14.04", "debian-8.2", "opensuse-13.1", "opensuse-13.2"]
+  excludes: ["ubuntu-12.04", "ubuntu-14.04", "debian-7.4", "opensuse-13.1", "opensuse-13.2"]
   attributes:
     postgresql:
       enable_pgdg_yum: true
@@ -122,20 +123,20 @@ suites:
   attributes:
     postgresql:
       enable_pgdg_apt: true
-      version: "9.3"
+      version: "9.4"
 
 - name: yum-pgdg-client-ruby
   run_list:
   - recipe[minitest-handler]
   - recipe[postgresql]
   - recipe[postgresql::ruby]
-  excludes: ["ubuntu-12.04", "ubuntu-14.04", "debian-8.2", "opensuse-13.1", "opensuse-13.2"]
+  excludes: ["ubuntu-12.04", "ubuntu-14.04", "debian-7.4", "opensuse-13.1", "opensuse-13.2"]
   attributes:
     postgresql:
       enable_pgdg_yum: true
-      version: "9.3"
+      version: "9.4"
       client:
-        packages: ["postgresql93", "postgresql93-devel"]
+        packages: ["postgresql94", "postgresql94-devel"]
 
 - name: apt-pgdg-server-pg_stat_statements
   run_list:
@@ -146,7 +147,7 @@ suites:
   attributes:
     postgresql:
       enable_pgdg_apt: true
-      version: "9.3"
+      version: "9.4"
       password:
         postgres: "iloverandompasswordsbutthiswilldo"
       config:
@@ -162,14 +163,14 @@ suites:
   - recipe[minitest-handler]
   - recipe[postgresql::ruby]
   - recipe[postgresql::contrib]
-  excludes: ["ubuntu-12.04", "ubuntu-14.04", "debian-8.2", "opensuse-13.1", "opensuse-13.2"]
+  excludes: ["ubuntu-12.04", "ubuntu-14.04", "debian-7.4", "opensuse-13.1", "opensuse-13.2"]
   attributes:
     postgresql:
       enable_pgdg_yum: true
-      version: "9.3"
+      version: "9.4"
       server:
-        packages: ["postgresql93-server"]
-        service_name: "postgresql-9.3"
+        packages: ["postgresql94-server"]
+        service_name: "postgresql-9.4"
       password:
         postgres: "iloverandompasswordsbutthiswilldo"
       config:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,19 +10,13 @@ platforms:
   run_list:
   - recipe[apt]
 
-- name: ubuntu-10.04
-  run_list:
-  - recipe[apt]
-
-- name: debian-7.4
+- name: debian-8.2
   run_list:
   - recipe[apt]
 
 - name: centos-7.0
 
 - name: centos-6.4
-
-- name: centos-5.10
 
 - name: opensuse-13.2
   driver:
@@ -53,7 +47,7 @@ suites:
   run_list:
   - recipe[minitest-handler]
   - recipe[postgresql]
-  excludes: ["centos-5.10", "centos-6.4", "centos-7.0", "opensuse-13.1", "opensuse-13.2"]
+  excludes: ["centos-6.4", "centos-7.0", "opensuse-13.1", "opensuse-13.2"]
   attributes:
     postgresql:
       enable_pgdg_apt: true
@@ -63,7 +57,7 @@ suites:
   run_list:
   - recipe[minitest-handler]
   - recipe[postgresql]
-  excludes: ["ubuntu-10.04", "ubuntu-12.04", "ubuntu-14.04", "debian-7.4", "opensuse-13.1", "opensuse-13.2"]
+  excludes: ["ubuntu-12.04", "ubuntu-14.04", "debian-8.2", "opensuse-13.1", "opensuse-13.2"]
   attributes:
     postgresql:
       enable_pgdg_yum: true
@@ -92,7 +86,7 @@ suites:
   - recipe[minitest-handler]
   - recipe[postgresql::ruby]
   - recipe[postgresql::server]
-  excludes: ["centos-5.10", "centos-6.4", "centos-7.0", "opensuse-13.1", "opensuse-13.2"]
+  excludes: ["centos-6.4", "centos-7.0", "opensuse-13.1", "opensuse-13.2"]
   attributes:
     postgresql:
       enable_pgdg_apt: true
@@ -108,14 +102,14 @@ suites:
   - recipe[minitest-handler]
   - recipe[postgresql::ruby]
   - recipe[postgresql::server]
-  excludes: ["ubuntu-10.04", "ubuntu-12.04", "ubuntu-14.04", "debian-7.4", "opensuse-13.1", "opensuse-13.2"]
+  excludes: ["ubuntu-12.04", "ubuntu-14.04", "debian-8.2", "opensuse-13.1", "opensuse-13.2"]
   attributes:
     postgresql:
       enable_pgdg_yum: true
-      version: "9.3"
+      version: "9.4"
       server:
-        packages: ["postgresql93-server"]
-        service_name: "postgresql-9.3"
+        packages: ["postgresql94-server"]
+        service_name: "postgresql-9.4"
       password:
         postgres: "iloverandompasswordsbutthiswilldo"
 
@@ -124,7 +118,7 @@ suites:
   - recipe[minitest-handler]
   - recipe[postgresql]
   - recipe[postgresql::ruby]
-  excludes: ["centos-5.10", "centos-6.4", "centos-7.0", "opensuse-13.1", "opensuse-13.2"]
+  excludes: ["centos-6.4", "centos-7.0", "opensuse-13.1", "opensuse-13.2"]
   attributes:
     postgresql:
       enable_pgdg_apt: true
@@ -135,7 +129,7 @@ suites:
   - recipe[minitest-handler]
   - recipe[postgresql]
   - recipe[postgresql::ruby]
-  excludes: ["ubuntu-10.04", "ubuntu-12.04", "ubuntu-14.04", "debian-7.4", "opensuse-13.1", "opensuse-13.2"]
+  excludes: ["ubuntu-12.04", "ubuntu-14.04", "debian-8.2", "opensuse-13.1", "opensuse-13.2"]
   attributes:
     postgresql:
       enable_pgdg_yum: true
@@ -148,7 +142,7 @@ suites:
   - recipe[minitest-handler]
   - recipe[postgresql::ruby]
   - recipe[postgresql::contrib]
-  excludes: ["centos-5.10", "centos-6.4", "centos-7.0", "opensuse-13.1", "opensuse-13.2"]
+  excludes: ["centos-6.4", "centos-7.0", "opensuse-13.1", "opensuse-13.2"]
   attributes:
     postgresql:
       enable_pgdg_apt: true
@@ -168,7 +162,7 @@ suites:
   - recipe[minitest-handler]
   - recipe[postgresql::ruby]
   - recipe[postgresql::contrib]
-  excludes: ["ubuntu-10.04", "ubuntu-12.04", "ubuntu-14.04", "debian-7.4", "opensuse-13.1", "opensuse-13.2"]
+  excludes: ["ubuntu-12.04", "ubuntu-14.04", "debian-8.2", "opensuse-13.1", "opensuse-13.2"]
   attributes:
     postgresql:
       enable_pgdg_yum: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@ postgresql Cookbook CHANGELOG
 =============================
 This file is used to list changes made in each version of the postgresql cookbook.
 
+v3.5.0
+-----
+* No more derived attributes in the attributes file
+* Correct issues which caused the inability to override installation version defaults
+* Start fixing things that are so old and crusty they need to be changed
+* Added more grey hair to my beard
+* Stopped doing things in ruby at compile time that have no place being evaluated at compile time
+
 v3.4.24
 -------
 * Corrections to address repositories signed with newer certificates that some distributions have in their default ca-certificates package

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Requirements
 
 Tested on:
 
-* Ubuntu 10.04, 11.10, 12.04, 14.04, 14.10
-* Red Hat 6.1, Scientific 6.1, CentOS 6.3
+* Ubuntu 12.04, 14.04, 14.10
+* Red Hat 6.1, Scientific 6.1, CentOS 6.3, 7.0, OpenSuse
 
 ## Cookbooks
 
@@ -68,10 +68,6 @@ The following attributes are set based on the platform, see the
 
 The following attributes are generated in
 `recipe[postgresql::server]`.
-
-* `node['postgresql']['password']['postgres']` - randomly generated
-  password by the `openssl` cookbook's library.
-  (TODO: This is broken, as it disables the password.)
 
 Configuration
 -------------
@@ -172,14 +168,6 @@ Installs the packages defined in the
 ruby
 ----
 
-**NOTE** This recipe may not currently work when installing Chef with
-  the
-  ["Omnibus" full stack installer](http://opscode.com/chef/install) on
-  some platforms due to an incompatibility with OpenSSL. See
-  [COOK-1406](http://tickets.opscode.com/browse/COOK-1406). You can
-  build from source into the Chef omnibus installation to work around
-  this issue.
-
 Install the `pg` gem under Chef's Ruby environment so it can be used
 in other recipes. The build-essential packages and postgresql client
 packages will be installed during the compile phase, so that the
@@ -193,7 +181,6 @@ appropriate server packages installed and service managed. Also
 manages the configuration for the server:
 
 * generates a strong default password (via `openssl`) for `postgres`
-  (TODO: This is broken, as it disables the password.)
 * sets the password for postgres
 * manages the `postgresql.conf` file.
 * manages the `pg_hba.conf` file.
@@ -449,7 +436,7 @@ License and Author
 - Author:: Lamont Granquist (<lamont@opscode.com>)
 - Author:: Chris Roberts (<chrisroberts.code@gmail.com>)
 - Author:: David Crane (<davidc@donorschoose.org>)
-- Author:: Aaron Baer (<aaron@hw-ops.com>)
+- Author:: Aaron Baer (<aaron@heavywater.io>)
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -131,11 +131,11 @@ when "ubuntu"
     default['postgresql']['contrib']['packages'] = ["postgresql-contrib-9.1"]
   else
     default['postgresql']['version'] = "9.3"
-    default['postgresql']['dir'] = "/etc/postgresql/9.4/main"
+    default['postgresql']['dir'] = "/etc/postgresql/9.3/main"
     default['postgresql']['server']['service_name'] = "postgresql"
-    default['postgresql']['client']['packages'] = ["postgresql-client-9.4","libpq-dev"]
-    default['postgresql']['server']['packages'] = ["postgresql-9.4"]
-    default['postgresql']['contrib']['packages'] = ["postgresql-contrib-9.4"]
+    default['postgresql']['client']['packages'] = ["postgresql-client-9.3","libpq-dev"]
+    default['postgresql']['server']['packages'] = ["postgresql-9.3"]
+    default['postgresql']['contrib']['packages'] = ["postgresql-contrib-9.3"]
   end
 
 when "fedora"
@@ -207,7 +207,7 @@ when "opensuse"
   default['postgresql']['server']['service_name'] = "postgresql"
 
 when "suse"
-    if node['platform_version'].to_f <= 11.1
+  if node['platform_version'].to_f <= 11.1
     default['postgresql']['version'] = "8.3"
     default['postgresql']['client']['packages'] = ['postgresql', 'rubygem-pg']
     default['postgresql']['server']['packages'] = ['postgresql-server']
@@ -233,22 +233,14 @@ end
 
 case node['platform_family']
 when 'debian'
-  default['postgresql']['config']['hba_file'] = "/etc/postgresql/#{node['postgresql']['version']}/main/pg_hba.conf"
-  default['postgresql']['config']['ident_file'] = "/etc/postgresql/#{node['postgresql']['version']}/main/pg_ident.conf"
-  default['postgresql']['config']['external_pid_file'] = "/var/run/postgresql/#{node['postgresql']['version']}-main.pid"
   default['postgresql']['config']['listen_addresses'] = 'localhost'
   default['postgresql']['config']['port'] = 5432
   default['postgresql']['config']['max_connections'] = 100
-  default['postgresql']['config']['unix_socket_directory'] = '/var/run/postgresql' if node['postgresql']['version'].to_f < 9.3
-  default['postgresql']['config']['unix_socket_directories'] = '/var/run/postgresql' if node['postgresql']['version'].to_f >= 9.3
   default['postgresql']['config']['shared_buffers'] = '24MB'
-  default['postgresql']['config']['max_fsm_pages'] = 153600 if node['postgresql']['version'].to_f < 8.4
   default['postgresql']['config']['log_line_prefix'] = '%t '
   default['postgresql']['config']['datestyle'] = 'iso, mdy'
   default['postgresql']['config']['default_text_search_config'] = 'pg_catalog.english'
   default['postgresql']['config']['ssl'] = true
-  default['postgresql']['config']['ssl_cert_file'] = '/etc/ssl/certs/ssl-cert-snakeoil.pem' if node['postgresql']['version'].to_f >= 9.2
-  default['postgresql']['config']['ssl_key_file'] = '/etc/ssl/private/ssl-cert-snakeoil.key'if node['postgresql']['version'].to_f >= 9.2
 when 'rhel', 'fedora', 'suse'
   default['postgresql']['config']['listen_addresses'] = 'localhost'
   default['postgresql']['config']['port'] = 5432

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -73,50 +73,70 @@ when "debian"
   case
   when node['platform_version'].to_f < 6.0 # All 5.X
     default['postgresql']['version'] = "8.3"
+    default['postgresql']['dir'] = "/etc/postgresql/8.3/main"
+    default['postgresql']['client']['packages'] = ["postgresql-client-8.3","libpq-dev"]
+    default['postgresql']['server']['packages'] = ["postgresql-8.3"]
+    default['postgresql']['contrib']['packages'] = ["postgresql-contrib-8.3"]
   when node['platform_version'].to_f < 7.0 # All 6.X
     default['postgresql']['version'] = "8.4"
+    default['postgresql']['dir'] = "/etc/postgresql/8.4/main"
+    default['postgresql']['client']['packages'] = ["postgresql-client-8.4","libpq-dev"]
+    default['postgresql']['server']['packages'] = ["postgresql-8.4"]
+    default['postgresql']['contrib']['packages'] = ["postgresql-contrib-8.4"]
   when node['platform_version'].to_f < 8.0 # All 7.X
     default['postgresql']['version'] = "9.1"
+    default['postgresql']['dir'] = "/etc/postgresql/9.1/main"
+    default['postgresql']['client']['packages'] = ["postgresql-client-9.1","libpq-dev"]
+    default['postgresql']['server']['packages'] = ["postgresql-9.1"]
+    default['postgresql']['contrib']['packages'] = ["postgresql-contrib-9.1"]
   else
     default['postgresql']['version'] = "9.4"
+    default['postgresql']['dir'] = "/etc/postgresql/9.4/main"
+    default['postgresql']['client']['packages'] = ["postgresql-client-9.4","libpq-dev"]
+    default['postgresql']['server']['packages'] = ["postgresql-9.4"]
+    default['postgresql']['contrib']['packages'] = ["postgresql-contrib-9.4"]
   end
 
-  default['postgresql']['dir'] = "/etc/postgresql/#{node['postgresql']['version']}/main"
   case
   when node['platform_version'].to_f < 6.0 # All 5.X
-    default['postgresql']['server']['service_name'] = "postgresql-#{node['postgresql']['version']}"
+    default['postgresql']['server']['service_name'] = "postgresql-8.3"
   else
     default['postgresql']['server']['service_name'] = "postgresql"
   end
 
-  default['postgresql']['client']['packages'] = ["postgresql-client-#{node['postgresql']['version']}","libpq-dev"]
-  default['postgresql']['server']['packages'] = ["postgresql-#{node['postgresql']['version']}"]
-  default['postgresql']['contrib']['packages'] = ["postgresql-contrib-#{node['postgresql']['version']}"]
 
 when "ubuntu"
 
   case
   when node['platform_version'].to_f <= 9.04
     default['postgresql']['version'] = "8.3"
+    default['postgresql']['dir'] = "/etc/postgresql/8.3/main"
+    default['postgresql']['server']['service_name'] = "postgresql-8.3"
+    default['postgresql']['client']['packages'] = ["postgresql-client-8.3","libpq-dev"]
+    default['postgresql']['server']['packages'] = ["postgresql-8.3"]
+    default['postgresql']['contrib']['packages'] = ["postgresql-contrib-8.3"]
   when node['platform_version'].to_f <= 11.04
     default['postgresql']['version'] = "8.4"
+    default['postgresql']['dir'] = "/etc/postgresql/8.4/main"
+    default['postgresql']['server']['service_name'] = "postgresql"
+    default['postgresql']['client']['packages'] = ["postgresql-client-8.4","libpq-dev"]
+    default['postgresql']['server']['packages'] = ["postgresql-8.4"]
+    default['postgresql']['contrib']['packages'] = ["postgresql-contrib-8.4"]
   when node['platform_version'].to_f <= 13.10
     default['postgresql']['version'] = "9.1"
+    default['postgresql']['dir'] = "/etc/postgresql/9.1/main"
+    default['postgresql']['server']['service_name'] = "postgresql"
+    default['postgresql']['client']['packages'] = ["postgresql-client-9.1","libpq-dev"]
+    default['postgresql']['server']['packages'] = ["postgresql-9.1"]
+    default['postgresql']['contrib']['packages'] = ["postgresql-contrib-9.1"]
   else
     default['postgresql']['version'] = "9.3"
-  end
-
-  default['postgresql']['dir'] = "/etc/postgresql/#{node['postgresql']['version']}/main"
-  case
-  when (node['platform_version'].to_f <= 10.04) && (! node['postgresql']['enable_pgdg_apt'])
-    default['postgresql']['server']['service_name'] = "postgresql-#{node['postgresql']['version']}"
-  else
+    default['postgresql']['dir'] = "/etc/postgresql/9.4/main"
     default['postgresql']['server']['service_name'] = "postgresql"
+    default['postgresql']['client']['packages'] = ["postgresql-client-9.4","libpq-dev"]
+    default['postgresql']['server']['packages'] = ["postgresql-9.4"]
+    default['postgresql']['contrib']['packages'] = ["postgresql-contrib-9.4"]
   end
-
-  default['postgresql']['client']['packages'] = ["postgresql-client-#{node['postgresql']['version']}","libpq-dev"]
-  default['postgresql']['server']['packages'] = ["postgresql-#{node['postgresql']['version']}"]
-  default['postgresql']['contrib']['packages'] = ["postgresql-contrib-#{node['postgresql']['version']}"]
 
 when "fedora"
 
@@ -126,22 +146,21 @@ when "fedora"
     default['postgresql']['version'] = "8.4"
   end
 
+  default['postgresql']['setup_script'] = "postgresql-setup"
+
   default['postgresql']['dir'] = "/var/lib/pgsql/data"
   default['postgresql']['client']['packages'] = %w{postgresql-devel}
   default['postgresql']['server']['packages'] = %w{postgresql-server}
   default['postgresql']['contrib']['packages'] = %w{postgresql-contrib}
   default['postgresql']['server']['service_name'] = "postgresql"
 
-  if node['postgresql']['version'].to_f >= 9.3
-    default['postgresql']['setup_script'] = "/usr/pgsql-#{node['postgresql']['version']}/bin/postgresql#{node['postgresql']['version'].split('.').join}-setup"
-  else
-    default['postgresql']['setup_script'] = "postgresql-setup"
-  end
-
 when "amazon"
 
-  if node['platform_version'].to_f >= 2012.03
+  if node['platform_version'].to_f == 2012.03
     default['postgresql']['version'] = "9.0"
+    default['postgresql']['dir'] = "/var/lib/pgsql9/data"
+  elsif node['platform_version'].to_f >= 2015.03
+    default['postgresql']['version'] = "9.2"
     default['postgresql']['dir'] = "/var/lib/pgsql9/data"
   else
     default['postgresql']['version'] = "8.4"
@@ -157,30 +176,17 @@ when "redhat", "centos", "scientific", "oracle"
 
   default['postgresql']['version'] = "8.4"
 
-  if node['postgresql']['version'].to_f >= 9.3
-    default['postgresql']['setup_script'] = "postgresql#{node['postgresql']['version'].split('.').join}-setup"
-  else
-    default['postgresql']['setup_script'] = "postgresql-setup"
-  end
+  default['postgresql']['client']['packages'] = ["postgresql84-devel"]
+  default['postgresql']['server']['packages'] = ["postgresql84-server"]
+  default['postgresql']['contrib']['packages'] = ["postgresql84-contrib"]
+
+  default['postgresql']['setup_script'] = "postgresql-setup"
+  default['postgresql']['server']['service_name'] = "postgresql"
 
   if node['platform_version'].to_f >= 6.0 && node['postgresql']['version'].to_f == 8.4
-    default['postgresql']['client']['packages'] = %w{postgresql-devel}
-    default['postgresql']['server']['packages'] = %w{postgresql-server}
-    default['postgresql']['contrib']['packages'] = %w{postgresql-contrib}
-  else
-    default['postgresql']['client']['packages'] = ["postgresql#{node['postgresql']['version'].split('.').join}-devel"]
-    default['postgresql']['server']['packages'] = ["postgresql#{node['postgresql']['version'].split('.').join}-server"]
-    default['postgresql']['contrib']['packages'] = ["postgresql#{node['postgresql']['version'].split('.').join}-contrib"]
-  end
-
-  if node['platform_version'].to_f >= 6.0 && node['postgresql']['version'].to_f != 8.4
-    if node['postgresql']['server']['init_package'] == 'systemd'
-      default['postgresql']['server']['service_name'] = "postgresql"
-    else
-      default['postgresql']['server']['service_name'] = "postgresql-#{node['postgresql']['version']}"
-    end
-  else
-    default['postgresql']['server']['service_name'] = "postgresql"
+    default['postgresql']['client']['packages'] = ['postgresql-devel']
+    default['postgresql']['server']['packages'] = ['postgresql-server']
+    default['postgresql']['contrib']['packages'] = ['postgresql-contrib']
   end
 
 when "opensuse"
@@ -218,25 +224,13 @@ when "suse"
 
 else
   default['postgresql']['version'] = "8.4"
-  default['postgresql']['dir'] = "/etc/postgresql/#{node['postgresql']['version']}/main"
+  default['postgresql']['dir'] = "/etc/postgresql/8.4/main"
   default['postgresql']['client']['packages'] = ["postgresql"]
   default['postgresql']['server']['packages'] = ["postgresql"]
   default['postgresql']['contrib']['packages'] = ["postgresql"]
   default['postgresql']['server']['service_name'] = "postgresql"
 end
 
-# These defaults have disparity between which postgresql configuration
-# settings are used because they were extracted from the original
-# configuration files that are now removed in favor of dynamic
-# generation.
-#
-# While the configuration ends up being the same as the default
-# in previous versions of the cookbook, the content of the rendered
-# template will change, and this will result in service notification
-# if you upgrade the cookbook on existing systems.
-#
-# The ssl config attribute is generated in the recipe to avoid awkward
-# merge/precedence order during the Chef run.
 case node['platform_family']
 when 'debian'
   default['postgresql']['config']['hba_file'] = "/etc/postgresql/#{node['postgresql']['version']}/main/pg_hba.conf"

--- a/attributes/yum_pgdg_packages.rb
+++ b/attributes/yum_pgdg_packages.rb
@@ -1,0 +1,452 @@
+# The PostgreSQL RPM Building Project built repository RPMs for easy
+# access to the PGDG yum repositories. Links to RPMs for installation
+# on the supported version/platform combinations are listed at
+# http://yum.postgresql.org/repopackages.php, and the links for
+# PostgreSQL 9.2, 9.3 and 9.4 are captured below.
+#
+default['postgresql']['pgdg']['repo_rpm_url'] = {
+  "9.4" => {
+    "redhat" => {
+      "7" => {
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-7-x86_64/",
+          "package" => "pgdg-redhat94-9.4-1.noarch.rpm"
+        }
+      },
+      "6" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-6-i386/",
+          "package" => "pgdg-redhat94-9.4-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/",
+          "package" => "pgdg-redhat94-9.4-1.noarch.rpm"
+        }
+      },
+      "5" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-5-i386/",
+          "package" => "pgdg-redhat94-9.4-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-5-x86_64/",
+          "package" => "pgdg-redhat94-9.4-1.noarch.rpm"
+        }
+      }
+    },
+    "centos" => {
+      "7" => {
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-7-x86_64/",
+          "package" => "pgdg-centos94-9.4-1.noarch.rpm"
+        }
+      },
+      "6" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-6-i386/",
+          "package" => "pgdg-centos94-9.4-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/",
+          "package" => "pgdg-centos94-9.4-1.noarch.rpm"
+        }
+      },
+      "5" => {
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-5-x86_64/",
+          "package" => "pgdg-centos94-9.4-1.noarch.rpm"
+        },
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-5-i386/",
+          "package" => "pgdg-centos94-9.4-1.noarch.rpm"
+        }
+      }
+    },
+    "fedora" => {
+      "22" => {
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.4/fedora/fedora-22-x86_64/",
+          "package" => "pgdg-fedora94-9.4-3.noarch.rpm"
+        }
+      },
+      "21" => {
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.4/fedora/fedora-21-x86_64/",
+          "package" => "pgdg-fedora94-9.4-2.noarch.rpm"
+      },
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.4/fedora/fedora-21-i686/",
+          "package" => "pgdg-fedora94-9.4-2.noarch.rpm"
+        }
+      },
+      "20" => {
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.4/fedora/fedora-20-x86_64/",
+          "package" => "pgdg-fedora94-9.4-1.noarch.rpm"
+        },
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.4/fedora/fedora-20-i686/",
+          "package" => "pgdg-fedora94-9.4-1.noarch.rpm"
+        }
+      }
+    },
+    "amazon" => {
+      "2015" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-6-i386/",
+          "package" => "pgdg-ami201503-94-9.4-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/",
+          "package" => "pgdg-ami201503-94-9.4-1.noarch.rpm"
+        }
+      }
+    },
+    "scientific" => {
+      "7" => {
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-7-x86_64/",
+          "package" => "pgdg-sl94-9.4-1.noarch.rpm"
+        }
+      },
+      "6" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-6-i386/",
+          "package" => "pgdg-sl94-9.4-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/",
+          "package" => "pgdg-sl94-9.4-1.noarch.rpm"
+        }
+      },
+      "5" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-5-i386/",
+          "package" => "pgdg-sl94-9.4-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-5-x86_64/",
+          "package" => "pgdg-sl94-9.4-1.noarch.rpm"
+        }
+      }
+    },
+    "oracle" => {
+      "7" => {
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-7-x86_64/",
+          "package" => "pgdg-oraclelinux94-9.4-1.noarch.rpm"
+        }
+      },
+      "6" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-6-i386/",
+          "package" => "pgdg-oraclelinux94-9.4-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/",
+          "package" => "pgdg-oraclelinux94-9.4-1.noarch.rpm"
+        }
+      }
+    }
+  },
+  "9.3" => {
+    "amazon" => {
+      "2015" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-i386/",
+          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-x86_64/",
+          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+        }
+      },
+      "2014" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-i386/",
+          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-x86_64/",
+          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+        }
+      },
+      "2013" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-i386/",
+          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-x86_64/",
+          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+        }
+      }
+    },
+    "centos" => {
+      "7" => {
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-7-x86_64/",
+          "package" => "pgdg-centos93-9.3-1.noarch.rpm"
+        }
+      },
+      "6" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-i386/",
+          "package" => "pgdg-centos93-9.3-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-x86_64/",
+          "package" => "pgdg-centos93-9.3-1.noarch.rpm"
+        }
+      },
+      "5" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-5-i386/",
+          "package" => "pgdg-centos93-9.3-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-5-x86_64/",
+          "package" => "pgdg-centos93-9.3-1.noarch.rpm"
+        }
+      }
+    },
+    "redhat" => {
+      "7" => {
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-7-x86_64/",
+          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+        }
+      },
+      "6" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-i386/",
+          "package" => "pgdg-redhat93-9.3-1.noarch.rpm",
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-x86_64/",
+          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+        }
+      },
+      "5" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-5-i386/",
+          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-5-x86_64/",
+          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+        }
+      }
+    },
+    "oracle" => {
+      "6" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-i386/",
+          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-x86_64/",
+          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+        }
+      },
+      "5" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-5-i386/",
+          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-5-x86_64/",
+          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+        }
+      }
+    },
+    "scientific" => {
+      "6" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-i386/",
+          "package" => "pgdg-sl93-9.3-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-x86_64/",
+          "package" => "pgdg-sl93-9.3-1.noarch.rpm"
+        }
+      },
+      "5" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-5-i386/",
+          "package" => "pgdg-sl93-9.3-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-5-x86_64/",
+          "package" => "pgdg-sl93-9.3-1.noarch.rpm"
+        }
+      }
+    },
+    "fedora" => {
+      "20" => {
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.3/fedora/fedora-20-x86_64/",
+          "pakcage" => "pgdg-fedora93-9.3-1.noarch.rpm"
+        }
+      },
+      "19" => {
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.3/fedora/fedora-19-x86_64/",
+          "pakcage" => "pgdg-fedora93-9.3-1.noarch.rpm"
+        }
+      },
+      "18" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.3/fedora/fedora-18-i386/",
+          "package" => "pgdg-fedora93-9.3-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.3/fedora/fedora-18-x86_64/",
+          "package" => "pgdg-fedora93-9.3-1.noarch.rpm"
+        }
+      },
+      "17" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.3/fedora/fedora-17-i386/",
+          "package" => "pgdg-fedora93-9.3-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.3/fedora/fedora-17-x86_64/",
+          "package" => "pgdg-fedora93-9.3-1.noarch.rpm"
+        }
+      }
+    }
+  },
+  "9.2" => {
+    "centos" => {
+      "6" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.2/redhat/rhel-6-i386/",
+          "package" => "pgdg-centos92-9.2-7.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.2/redhat/rhel-6-x86_64/",
+          "package" => "pgdg-centos92-9.2-7.noarch.rpm"
+        }
+      },
+      "5" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.2/redhat/rhel-5-i386/",
+          "package" => "pgdg-centos92-9.2-7.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.2/redhat/rhel-5-x86_64/",
+          "package" => "pgdg-centos92-9.2-7.noarch.rpm"
+        }
+      }
+    },
+    "redhat" => {
+      "6" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.2/redhat/rhel-6-i386/",
+          "package" => "pgdg-redhat92-9.2-7.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.2/redhat/rhel-6-x86_64/",
+          "package" => "pgdg-redhat92-9.2-7.noarch.rpm"
+        }
+      },
+      "5" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.2/redhat/rhel-5-i386/",
+          "package" => "pgdg-redhat92-9.2-7.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.2/redhat/rhel-5-x86_64/",
+          "package" => "pgdg-redhat92-9.2-7.noarch.rpm"
+        }
+      }
+    },
+    "oracle" => {
+      "6" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.2/redhat/rhel-6-i386/",
+          "package" => "pgdg-redhat92-9.2-7.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.2/redhat/rhel-6-x86_64/",
+          "package" => "pgdg-redhat92-9.2-7.noarch.rpm"
+        }
+      },
+      "5" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.2/redhat/rhel-5-i386/",
+          "package" => "pgdg-redhat92-9.2-7.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.2/redhat/rhel-5-x86_64/",
+          "package" => "pgdg-redhat92-9.2-7.noarch.rpm"
+        }
+      }
+    },
+    "scientific" => {
+      "6" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.2/redhat/rhel-6-i386/",
+          "package" => "pgdg-sl92-9.2-8.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.2/redhat/rhel-6-x86_64/",
+          "package" => "pgdg-sl92-9.2-8.noarch.rpm"
+        }
+      },
+      "5" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.2/redhat/rhel-5-i386/",
+          "package" => "pgdg-sl92-9.2-8.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.2/redhat/rhel-5-x86_64/",
+          "package" => "pgdg-sl92-9.2-8.noarch.rpm"
+        }
+      }
+    },
+    "fedora" => {
+      "19" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.2/fedora/fedora-19-i386/",
+          "package" => "pgdg-fedora92-9.2-6.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.2/fedora/fedora-19-x86_64/",
+          "package" => "pgdg-fedora92-9.2-6.noarch.rpm"
+        }
+      },
+      "18" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.2/fedora/fedora-18-i386/",
+          "package" => "pgdg-fedora92-9.2-6.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.2/fedora/fedora-18-x86_64/",
+          "package" => "pgdg-fedora92-9.2-6.noarch.rpm"
+        }
+      },
+      "17" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.2/fedora/fedora-17-i386/",
+          "package" => "pgdg-fedora92-9.2-6.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.2/fedora/fedora-17-x86_64/",
+          "package" => "pgdg-fedora92-9.2-5.noarch.rpm"
+        }
+      },
+      "16" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.2/fedora/fedora-16-i386/",
+          "package" => "pgdg-fedora92-9.2-5.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.2/fedora/fedora-16-x86_64/",
+          "package" => "pgdg-fedora92-9.2-5.noarch.rpm"
+        }
+      }
+    }
+  }
+}

--- a/files/default/tests/minitest/apt_pgdg_postgresql_test.rb
+++ b/files/default/tests/minitest/apt_pgdg_postgresql_test.rb
@@ -28,12 +28,12 @@ describe 'postgresql::apt_pgdg_postgresql' do
     file("/etc/apt/sources.list.d/apt.postgresql.org.list").must_exist
   end
 
-  it 'installs postgresql-client-9.3' do
-    package("postgresql-client-9.3").must_be_installed
+  it 'installs postgresql-client-9.4' do
+    package("postgresql-client-9.4").must_be_installed
   end
 
-  it 'makes psql version 9.3 available' do
+  it 'makes psql version 9.4 available' do
     psql = shell_out("psql --version")
-    assert psql.stdout.include?("psql (PostgreSQL) 9.3")
+    assert psql.stdout.include?("psql (PostgreSQL) 9.4")
   end
 end

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -348,30 +348,6 @@ def extension_installed?(pg_ext)
   end
 end
 
-######################################
-# Function to build information needed to install RPM for PGDG yum repository,
-# since PGDG supports several versions of PostgreSQL, platforms, platform versions
-# and architectures.
-# Links to RPMs for installation are in an attribute so that new versions/platforms
-# can be more easily added. (See attributes/default.rb)
-def pgdgrepo_rpm_info
-  repo_rpm_url = node['postgresql']['pgdg']['repo_rpm_url'].
-    fetch(node['postgresql']['version']).            # e.g., fetch for "9.1"
-    fetch(node['platform']).                         # e.g., fetch for "centos"
-    fetch(node['platform_version'].to_f.to_i.to_s).  # e.g., fetch for "5" (truncated "5.7")
-    fetch(node['kernel']['machine'])                 # e.g., fetch for "i386" or "x86_64"
-
-  # Extract the filename portion from the URL for the PGDG repository RPM.
-  # E.g., repo_rpm_filename = "pgdg-centos92-9.2-6.noarch.rpm"
-  repo_rpm_filename = File.basename(repo_rpm_url)
-
-  # Extract the package name from the URL for the PGDG repository RPM.
-  # E.g., repo_rpm_package = "pgdg-centos92"
-  repo_rpm_package = repo_rpm_filename.split(/-/,3)[0..1].join('-')
-
-  return [ repo_rpm_url, repo_rpm_filename, repo_rpm_package ]
-end
-
 # End the Opscode::PostgresqlHelpers module
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "support@hw-ops.com"
 license           "Apache 2.0"
 description       "Installs and configures postgresql for clients or servers"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "3.4.25"
+version           "3.5.0"
 recipe            "postgresql", "Includes postgresql::client"
 recipe            "postgresql::ruby", "Installs pg gem for Ruby bindings"
 recipe            "postgresql::client", "Installs postgresql client package(s)"

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -17,18 +17,21 @@
 
 include_recipe "postgresql::ca_certificates"
 
-if platform_family?('debian') && node['postgresql']['version'].to_f > 9.3
-  node.default['postgresql']['enable_pgdg_apt'] = true
+case node['platform_family']
+when 'debian'
+  if node['postgresql']['version'].to_f > 9.3
+    node.set['postgresql']['enable_pgdg_apt'] = true
+  end
+
+  if node['postgresql']['enable_pgdg_apt']
+    include_recipe 'postgresql::apt_pgdg_postgresql'
+  end
+when 'rhel'
+  if node['postgresql']['enable_pgdg_yum']
+    include_recipe 'postgresql::yum_pgdg_postgresql'
+  end
 end
 
-if(node['postgresql']['enable_pgdg_apt']) and platform_family?('debian')
-  include_recipe 'postgresql::apt_pgdg_postgresql'
-end
-
-if(node['postgresql']['enable_pgdg_yum']) and platform_family?('rhel')
-  include_recipe 'postgresql::yum_pgdg_postgresql'
-end
-
-node['postgresql']['client']['packages'].each do |pg_pack|
-  package pg_pack
+node['postgresql']['client']['packages'].each do |pkg|
+  package pkg
 end

--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -60,9 +60,22 @@ rescue LoadError
     include_recipe "postgresql::apt_pgdg_postgresql"
     resources("file[remove deprecated Pitti PPA apt repository]").run_action(:delete)
     resources("apt_repository[apt.postgresql.org]").run_action(:add)
+
+    node['postgresql']['client']['packages'].each do |pkg|
+      package pkg do
+        action :nothing
+      end.run_action(:install)
+    end
+
   end
 
   include_recipe "postgresql::client"
+
+  node['postgresql']['client']['packages'].each do |pkg|
+    package pkg do
+      action :nothing
+    end.run_action(:install)
+  end
 
   begin
     chef_gem "pg"

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -53,8 +53,11 @@ end
 # since they do things slightly differently.
 case node['platform_family']
 when "rhel", "fedora", "suse"
+  node.set['postgresql']['dir'] = "/var/lib/pgsql/#{node['postgresql']['version']}/data"
+  node.set['postgresql']['config']['data_directory'] = "/var/lib/pgsql/#{node['postgresql']['version']}/data"
   include_recipe "postgresql::server_redhat"
 when "debian"
+  node.set['postgresql']['config']['data_directory'] = "/var/lib/postgresql/#{node['postgresql']['version']}/main"
   include_recipe "postgresql::server_debian"
 end
 

--- a/recipes/server_conf.rb
+++ b/recipes/server_conf.rb
@@ -17,6 +17,28 @@
 
 change_notify = node['postgresql']['server']['config_change_notify']
 
+# There are some configuration items which depend on correctly evaluating the intended version being installed
+if node['platform_family'] == 'debian'
+
+  node.set['postgresql']['config']['hba_file'] = "/etc/postgresql/#{node['postgresql']['version']}/main/pg_hba.conf"
+  node.set['postgresql']['config']['ident_file'] = "/etc/postgresql/#{node['postgresql']['version']}/main/pg_ident.conf"
+  node.set['postgresql']['config']['external_pid_file'] = "/var/run/postgresql/#{node['postgresql']['version']}-main.pid"
+
+  if node['postgresql']['version'].to_f < 9.3
+    node.set['postgresql']['config']['unix_socket_directory'] = '/var/run/postgresql'
+  else
+    node.set['postgresql']['config']['unix_socket_directories'] = '/var/run/postgresql'
+  end
+
+  node.set['postgresql']['config']['max_fsm_pages'] = 153600 if node['postgresql']['version'].to_f < 8.4
+
+  if node['postgresql']['config']['ssl']
+    node.set['postgresql']['config']['ssl_cert_file'] = '/etc/ssl/certs/ssl-cert-snakeoil.pem' if node['postgresql']['version'].to_f >= 9.2
+    node.set['postgresql']['config']['ssl_key_file'] = '/etc/ssl/private/ssl-cert-snakeoil.key'if node['postgresql']['version'].to_f >= 9.2
+  end
+
+end
+
 template "#{node['postgresql']['dir']}/postgresql.conf" do
   source "postgresql.conf.erb"
   owner "postgres"

--- a/recipes/server_redhat.rb
+++ b/recipes/server_redhat.rb
@@ -18,7 +18,6 @@
 include_recipe "postgresql::client"
 
 svc_name = node['postgresql']['server']['service_name']
-dir = node['postgresql']['dir']
 initdb_locale = node['postgresql']['initdb_locale']
 
 shortver = node['postgresql']['version'].split('.').join
@@ -40,7 +39,7 @@ user "postgres" do
   supports :manage_home => false
 end
 
-directory dir do
+directory node['postgresql']['config']['data_directory'] do
   owner "postgres"
   group "postgres"
   recursive true
@@ -88,22 +87,24 @@ unless node['postgresql']['server']['init_package'] == 'systemd'
 
 end
 
+Chef::Log::warn("#{node['postgresql']['config']['data_directory']}/PG_VERSION")
+
 if node['postgresql']['server']['init_package'] == 'systemd'
 
   execute "#{node['postgresql']['setup_script']} initdb #{svc_name}" do
-    not_if { ::FileTest.exist?(File.join(dir, "PG_VERSION")) }
+    not_if { ::File.exist?("#{node['postgresql']['config']['data_directory']}/PG_VERSION") }
   end
 
 elsif (!platform_family?("suse") && node['postgresql']['version'].to_f <= 9.3)
 
   execute "/sbin/service #{svc_name} initdb #{initdb_locale}" do
-    not_if { ::FileTest.exist?(File.join(dir, "PG_VERSION")) }
+    not_if { ::File.exist?("#{node['postgresql']['config']['data_directory']}/PG_VERSION") }
   end
 
 else
 
   execute "/sbin/service #{svc_name} initdb" do
-    not_if { ::FileTest.exist?(File.join(dir, "PG_VERSION")) }
+    not_if { ::File.exist?("#{node['postgresql']['config']['data_directory']}/PG_VERSION") }
   end
 
 end

--- a/recipes/server_redhat.rb
+++ b/recipes/server_redhat.rb
@@ -94,9 +94,15 @@ if node['postgresql']['server']['init_package'] == 'systemd'
     not_if { ::FileTest.exist?(File.join(dir, "PG_VERSION")) }
   end
 
-elsif !platform_family?("suse")
+elsif (!platform_family?("suse") && node['postgresql']['version'].to_f <= 9.3)
 
   execute "/sbin/service #{svc_name} initdb #{initdb_locale}" do
+    not_if { ::FileTest.exist?(File.join(dir, "PG_VERSION")) }
+  end
+
+else
+
+  execute "/sbin/service #{svc_name} initdb" do
     not_if { ::FileTest.exist?(File.join(dir, "PG_VERSION")) }
   end
 

--- a/recipes/yum_pgdg_postgresql.rb
+++ b/recipes/yum_pgdg_postgresql.rb
@@ -28,7 +28,14 @@
 # PGDG repository properly. Conflicts will arise if postgresql9X does
 # appear in your distro's repo and you want a more recent patch level.
 
-repo_rpm_url, repo_rpm_filename, repo_rpm_package = pgdgrepo_rpm_info
+version = node['postgresql']['version']
+rpm_platform = node['platform']
+rpm_platform_version = node['platform_version'].to_f.to_i.to_s
+arch = node['kernel']['machine']
+
+repo_rpm_url = node[:postgresql][:pgdg][:repo_rpm_url][version][rpm_platform][rpm_platform_version][arch]
+repo_rpm_filename = File.basename(repo_rpm_url)
+repo_rpm_package = repo_rpm_filename.split(/-/,3)[0..1].join('-')
 
 # Download the PGDG repository RPM as a local file
 remote_file "#{Chef::Config[:file_cache_path]}/#{repo_rpm_filename}" do

--- a/recipes/yum_pgdg_postgresql.rb
+++ b/recipes/yum_pgdg_postgresql.rb
@@ -15,10 +15,6 @@
 # limitations under the License.
 #
 
-#######
-# Load the pgdgrepo_rpm_info method from libraries/default.rb
-::Chef::Recipe.send(:include, Opscode::PostgresqlHelpers)
-
 ######################################
 # Install the "PostgreSQL RPM Building Project - Yum Repository" through
 # the repo_rpm_url determined with pgdgrepo_rpm_info method from
@@ -28,25 +24,19 @@
 # PGDG repository properly. Conflicts will arise if postgresql9X does
 # appear in your distro's repo and you want a more recent patch level.
 
-version = node['postgresql']['version']
 rpm_platform = node['platform']
 rpm_platform_version = node['platform_version'].to_f.to_i.to_s
 arch = node['kernel']['machine']
 
-repo_rpm_url = node[:postgresql][:pgdg][:repo_rpm_url][version][rpm_platform][rpm_platform_version][arch]
-repo_rpm_filename = File.basename(repo_rpm_url)
-repo_rpm_package = repo_rpm_filename.split(/-/,3)[0..1].join('-')
-
 # Download the PGDG repository RPM as a local file
-remote_file "#{Chef::Config[:file_cache_path]}/#{repo_rpm_filename}" do
-  source repo_rpm_url
+remote_file "#{Chef::Config[:file_cache_path]}/#{node[:postgresql][:pgdg][:repo_rpm_url][node[:postgresql][:version]][rpm_platform][rpm_platform_version][arch][:package]}" do
+  source "#{node[:postgresql][:pgdg][:repo_rpm_url][node[:postgresql][:version]][rpm_platform][rpm_platform_version][arch][:url]}#{node[:postgresql][:pgdg][:repo_rpm_url][node[:postgresql][:version]][rpm_platform][rpm_platform_version][arch][:package]}"
   mode "0644"
 end
 
 # Install the PGDG repository RPM from the local file
-# E.g., /etc/yum.repos.d/pgdg-91-centos.repo
-package repo_rpm_package do
+package "#{node[:postgresql][:pgdg][:repo_rpm_url][node[:postgresql][:version]][rpm_platform][rpm_platform_version][arch][:package]}" do
   provider Chef::Provider::Package::Rpm
-  source "#{Chef::Config[:file_cache_path]}/#{repo_rpm_filename}"
+  source "#{Chef::Config[:file_cache_path]}/#{node[:postgresql][:pgdg][:repo_rpm_url][node[:postgresql][:version]][rpm_platform][rpm_platform_version][arch][:package]}"
   action :install
 end


### PR DESCRIPTION
When the original helper method was used there could be a scenario where the compile time attribute evaluation would be inconsistent with the run time attributes which were intended to be used.