### PR TITLE
Postgresql Cookbook 4.0.0

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,19 +10,13 @@ platforms:
   run_list:
   - recipe[apt]
 
-- name: ubuntu-10.04
-  run_list:
-  - recipe[apt]
-
-- name: debian-7.4
+- name: debian-8.2
   run_list:
   - recipe[apt]
 
 - name: centos-7.0
 
 - name: centos-6.4
-
-- name: centos-5.10
 
 - name: opensuse-13.2
   driver:
@@ -53,23 +47,23 @@ suites:
   run_list:
   - recipe[minitest-handler]
   - recipe[postgresql]
-  excludes: ["centos-5.10", "centos-6.4", "centos-7.0", "opensuse-13.1", "opensuse-13.2"]
+  excludes: ["centos-6.4", "centos-7.0", "opensuse-13.1", "opensuse-13.2"]
   attributes:
     postgresql:
       enable_pgdg_apt: true
-      version: "9.3"
+      version: "9.4"
 
 - name: yum-pgdg-client
   run_list:
   - recipe[minitest-handler]
   - recipe[postgresql]
-  excludes: ["ubuntu-10.04", "ubuntu-12.04", "ubuntu-14.04", "debian-7.4", "opensuse-13.1", "opensuse-13.2"]
+  excludes: ["ubuntu-12.04", "ubuntu-14.04", "debian-8.2", "opensuse-13.1", "opensuse-13.2"]
   attributes:
     postgresql:
       enable_pgdg_yum: true
-      version: "9.3"
+      version: "9.4"
       client:
-        packages: ["postgresql93"]
+        packages: ["postgresql94"]
 
 - name: ruby
   run_list:
@@ -79,8 +73,9 @@ suites:
 
 - name: server
   run_list:
-  - recipe[postgresql::ruby]
+  - recipe[apt]
   - recipe[minitest-handler]
+  - recipe[postgresql::ruby]
   - recipe[postgresql::server]
   attributes:
     postgresql:
@@ -92,11 +87,11 @@ suites:
   - recipe[minitest-handler]
   - recipe[postgresql::ruby]
   - recipe[postgresql::server]
-  excludes: ["centos-5.10", "centos-6.4", "centos-7.0", "opensuse-13.1", "opensuse-13.2"]
+  excludes: ["centos-6.4", "centos-7.0", "opensuse-13.1", "opensuse-13.2"]
   attributes:
     postgresql:
       enable_pgdg_apt: true
-      version: "9.3"
+      version: "9.4"
       password:
         postgres: "iloverandompasswordsbutthiswilldo"
       config:
@@ -108,14 +103,17 @@ suites:
   - recipe[minitest-handler]
   - recipe[postgresql::ruby]
   - recipe[postgresql::server]
-  excludes: ["ubuntu-10.04", "ubuntu-12.04", "ubuntu-14.04", "debian-7.4", "opensuse-13.1", "opensuse-13.2"]
+  excludes: ["ubuntu-12.04", "ubuntu-14.04", "debian-7.4", "opensuse-13.1", "opensuse-13.2"]
   attributes:
     postgresql:
       enable_pgdg_yum: true
-      version: "9.3"
+      version: "9.4"
       server:
-        packages: ["postgresql93-server"]
-        service_name: "postgresql-9.3"
+        packages: ["postgresql94-server"]
+        service_name: "postgresql-9.4"
+      client:
+        packages: ["postgresql94", "postgresql94-devel"]
+      setup_script: "postgresql94-setup"
       password:
         postgres: "iloverandompasswordsbutthiswilldo"
 
@@ -124,35 +122,35 @@ suites:
   - recipe[minitest-handler]
   - recipe[postgresql]
   - recipe[postgresql::ruby]
-  excludes: ["centos-5.10", "centos-6.4", "centos-7.0", "opensuse-13.1", "opensuse-13.2"]
+  excludes: ["centos-6.4", "centos-7.0", "opensuse-13.1", "opensuse-13.2"]
   attributes:
     postgresql:
       enable_pgdg_apt: true
-      version: "9.3"
+      version: "9.4"
 
 - name: yum-pgdg-client-ruby
   run_list:
   - recipe[minitest-handler]
   - recipe[postgresql]
   - recipe[postgresql::ruby]
-  excludes: ["ubuntu-10.04", "ubuntu-12.04", "ubuntu-14.04", "debian-7.4", "opensuse-13.1", "opensuse-13.2"]
+  excludes: ["ubuntu-12.04", "ubuntu-14.04", "debian-7.4", "opensuse-13.1", "opensuse-13.2"]
   attributes:
     postgresql:
       enable_pgdg_yum: true
-      version: "9.3"
+      version: "9.4"
       client:
-        packages: ["postgresql93", "postgresql93-devel"]
+        packages: ["postgresql94", "postgresql94-devel"]
 
 - name: apt-pgdg-server-pg_stat_statements
   run_list:
   - recipe[minitest-handler]
   - recipe[postgresql::ruby]
   - recipe[postgresql::contrib]
-  excludes: ["centos-5.10", "centos-6.4", "centos-7.0", "opensuse-13.1", "opensuse-13.2"]
+  excludes: ["centos-6.4", "centos-7.0", "opensuse-13.1", "opensuse-13.2"]
   attributes:
     postgresql:
       enable_pgdg_apt: true
-      version: "9.3"
+      version: "9.4"
       password:
         postgres: "iloverandompasswordsbutthiswilldo"
       config:
@@ -168,14 +166,14 @@ suites:
   - recipe[minitest-handler]
   - recipe[postgresql::ruby]
   - recipe[postgresql::contrib]
-  excludes: ["ubuntu-10.04", "ubuntu-12.04", "ubuntu-14.04", "debian-7.4", "opensuse-13.1", "opensuse-13.2"]
+  excludes: ["ubuntu-12.04", "ubuntu-14.04", "debian-7.4", "opensuse-13.1", "opensuse-13.2"]
   attributes:
     postgresql:
       enable_pgdg_yum: true
-      version: "9.3"
+      version: "9.4"
       server:
-        packages: ["postgresql93-server"]
-        service_name: "postgresql-9.3"
+        packages: ["postgresql94-server"]
+        service_name: "postgresql-9.4"
       password:
         postgres: "iloverandompasswordsbutthiswilldo"
       config:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@ postgresql Cookbook CHANGELOG
 =============================
 This file is used to list changes made in each version of the postgresql cookbook.
 
+v4.0.0
+-----
+* Potential breaking change: Restructured default attributes to avoid compile time deriving other attribute values from value of the `node[‘postgresql’][‘version’]`
+(#313, #302, #295, #288, #280, #261, #260, #254, #248, #217, #214, #167, #143)
+* Correct issues which caused the inability to override installation version defaults
+* Correct issues which caused configuration file entries with miss matching version numbers and incorrect file system paths being defined
+* Remove method pgdgrepo_rpm_info compile time use of derived attributes case many issues
+* Use correct directory path and check for the correct not_if condition to determine if the database has been initialized
+* Ensure that correct packages are installed in all scenarios where pg gem is compiled
+* Fix errors in configuration files for unix_socket_directory and unix_socket_directories
+* Updates to test-kitchen suite configuration
+* Added more grey hair to my beard
+
 v3.4.24
 -------
 * Corrections to address repositories signed with newer certificates that some distributions have in their default ca-certificates package

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Requirements
 
 Tested on:
 
-* Ubuntu 10.04, 11.10, 12.04, 14.04, 14.10
-* Red Hat 6.1, Scientific 6.1, CentOS 6.3
+* Ubuntu 12.04, 14.04, 14.10
+* Red Hat 6.1, Scientific 6.1, CentOS 6.3, 7.0, OpenSuse
 
 ## Cookbooks
 
@@ -68,10 +68,6 @@ The following attributes are set based on the platform, see the
 
 The following attributes are generated in
 `recipe[postgresql::server]`.
-
-* `node['postgresql']['password']['postgres']` - randomly generated
-  password by the `openssl` cookbook's library.
-  (TODO: This is broken, as it disables the password.)
 
 Configuration
 -------------
@@ -172,14 +168,6 @@ Installs the packages defined in the
 ruby
 ----
 
-**NOTE** This recipe may not currently work when installing Chef with
-  the
-  ["Omnibus" full stack installer](http://opscode.com/chef/install) on
-  some platforms due to an incompatibility with OpenSSL. See
-  [COOK-1406](http://tickets.opscode.com/browse/COOK-1406). You can
-  build from source into the Chef omnibus installation to work around
-  this issue.
-
 Install the `pg` gem under Chef's Ruby environment so it can be used
 in other recipes. The build-essential packages and postgresql client
 packages will be installed during the compile phase, so that the
@@ -193,7 +181,6 @@ appropriate server packages installed and service managed. Also
 manages the configuration for the server:
 
 * generates a strong default password (via `openssl`) for `postgres`
-  (TODO: This is broken, as it disables the password.)
 * sets the password for postgres
 * manages the `postgresql.conf` file.
 * manages the `pg_hba.conf` file.
@@ -449,7 +436,7 @@ License and Author
 - Author:: Lamont Granquist (<lamont@opscode.com>)
 - Author:: Chris Roberts (<chrisroberts.code@gmail.com>)
 - Author:: David Crane (<davidc@donorschoose.org>)
-- Author:: Aaron Baer (<aaron@hw-ops.com>)
+- Author:: Aaron Baer (<aaron@heavywater.io>)
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,6 +16,8 @@
 #
 
 default['postgresql']['enable_pgdg_apt'] = false
+default['postgresql']['enable_pgdg_yum'] = false
+
 default['postgresql']['server']['config_change_notify'] = :restart
 default['postgresql']['assign_postgres_password'] = true
 
@@ -73,50 +75,70 @@ when "debian"
   case
   when node['platform_version'].to_f < 6.0 # All 5.X
     default['postgresql']['version'] = "8.3"
+    default['postgresql']['dir'] = "/etc/postgresql/8.3/main"
+    default['postgresql']['client']['packages'] = ["postgresql-client-8.3","libpq-dev"]
+    default['postgresql']['server']['packages'] = ["postgresql-8.3"]
+    default['postgresql']['contrib']['packages'] = ["postgresql-contrib-8.3"]
   when node['platform_version'].to_f < 7.0 # All 6.X
     default['postgresql']['version'] = "8.4"
+    default['postgresql']['dir'] = "/etc/postgresql/8.4/main"
+    default['postgresql']['client']['packages'] = ["postgresql-client-8.4","libpq-dev"]
+    default['postgresql']['server']['packages'] = ["postgresql-8.4"]
+    default['postgresql']['contrib']['packages'] = ["postgresql-contrib-8.4"]
   when node['platform_version'].to_f < 8.0 # All 7.X
     default['postgresql']['version'] = "9.1"
+    default['postgresql']['dir'] = "/etc/postgresql/9.1/main"
+    default['postgresql']['client']['packages'] = ["postgresql-client-9.1","libpq-dev"]
+    default['postgresql']['server']['packages'] = ["postgresql-9.1"]
+    default['postgresql']['contrib']['packages'] = ["postgresql-contrib-9.1"]
   else
     default['postgresql']['version'] = "9.4"
+    default['postgresql']['dir'] = "/etc/postgresql/9.4/main"
+    default['postgresql']['client']['packages'] = ["postgresql-client-9.4","libpq-dev"]
+    default['postgresql']['server']['packages'] = ["postgresql-9.4"]
+    default['postgresql']['contrib']['packages'] = ["postgresql-contrib-9.4"]
   end
 
-  default['postgresql']['dir'] = "/etc/postgresql/#{node['postgresql']['version']}/main"
   case
   when node['platform_version'].to_f < 6.0 # All 5.X
-    default['postgresql']['server']['service_name'] = "postgresql-#{node['postgresql']['version']}"
+    default['postgresql']['server']['service_name'] = "postgresql-8.3"
   else
     default['postgresql']['server']['service_name'] = "postgresql"
   end
 
-  default['postgresql']['client']['packages'] = ["postgresql-client-#{node['postgresql']['version']}","libpq-dev"]
-  default['postgresql']['server']['packages'] = ["postgresql-#{node['postgresql']['version']}"]
-  default['postgresql']['contrib']['packages'] = ["postgresql-contrib-#{node['postgresql']['version']}"]
 
 when "ubuntu"
 
   case
   when node['platform_version'].to_f <= 9.04
     default['postgresql']['version'] = "8.3"
+    default['postgresql']['dir'] = "/etc/postgresql/8.3/main"
+    default['postgresql']['server']['service_name'] = "postgresql-8.3"
+    default['postgresql']['client']['packages'] = ["postgresql-client-8.3","libpq-dev"]
+    default['postgresql']['server']['packages'] = ["postgresql-8.3"]
+    default['postgresql']['contrib']['packages'] = ["postgresql-contrib-8.3"]
   when node['platform_version'].to_f <= 11.04
     default['postgresql']['version'] = "8.4"
+    default['postgresql']['dir'] = "/etc/postgresql/8.4/main"
+    default['postgresql']['server']['service_name'] = "postgresql"
+    default['postgresql']['client']['packages'] = ["postgresql-client-8.4","libpq-dev"]
+    default['postgresql']['server']['packages'] = ["postgresql-8.4"]
+    default['postgresql']['contrib']['packages'] = ["postgresql-contrib-8.4"]
   when node['platform_version'].to_f <= 13.10
     default['postgresql']['version'] = "9.1"
+    default['postgresql']['dir'] = "/etc/postgresql/9.1/main"
+    default['postgresql']['server']['service_name'] = "postgresql"
+    default['postgresql']['client']['packages'] = ["postgresql-client-9.1","libpq-dev"]
+    default['postgresql']['server']['packages'] = ["postgresql-9.1"]
+    default['postgresql']['contrib']['packages'] = ["postgresql-contrib-9.1"]
   else
     default['postgresql']['version'] = "9.3"
-  end
-
-  default['postgresql']['dir'] = "/etc/postgresql/#{node['postgresql']['version']}/main"
-  case
-  when (node['platform_version'].to_f <= 10.04) && (! node['postgresql']['enable_pgdg_apt'])
-    default['postgresql']['server']['service_name'] = "postgresql-#{node['postgresql']['version']}"
-  else
+    default['postgresql']['dir'] = "/etc/postgresql/9.3/main"
     default['postgresql']['server']['service_name'] = "postgresql"
+    default['postgresql']['client']['packages'] = ["postgresql-client-9.3","libpq-dev"]
+    default['postgresql']['server']['packages'] = ["postgresql-9.3"]
+    default['postgresql']['contrib']['packages'] = ["postgresql-contrib-9.3"]
   end
-
-  default['postgresql']['client']['packages'] = ["postgresql-client-#{node['postgresql']['version']}","libpq-dev"]
-  default['postgresql']['server']['packages'] = ["postgresql-#{node['postgresql']['version']}"]
-  default['postgresql']['contrib']['packages'] = ["postgresql-contrib-#{node['postgresql']['version']}"]
 
 when "fedora"
 
@@ -126,21 +148,21 @@ when "fedora"
     default['postgresql']['version'] = "8.4"
   end
 
+  default['postgresql']['setup_script'] = "postgresql-setup"
+
   default['postgresql']['dir'] = "/var/lib/pgsql/data"
   default['postgresql']['client']['packages'] = %w{postgresql-devel}
   default['postgresql']['server']['packages'] = %w{postgresql-server}
   default['postgresql']['contrib']['packages'] = %w{postgresql-contrib}
   default['postgresql']['server']['service_name'] = "postgresql"
-  default['postgresql']['setup_script'] = "postgresql-setup"
-
-  if node['postgresql']['version'].to_f >= 9.3
-    default['postgresql']['setup_script'] = "/usr/pgsql-#{node['postgresql']['version']}/bin/postgresql#{node['postgresql']['version'].split('.').join}-setup"
-  end
 
 when "amazon"
 
-  if node['platform_version'].to_f >= 2012.03
+  if node['platform_version'].to_f == 2012.03
     default['postgresql']['version'] = "9.0"
+    default['postgresql']['dir'] = "/var/lib/pgsql9/data"
+  elsif node['platform_version'].to_f >= 2015.03
+    default['postgresql']['version'] = "9.2"
     default['postgresql']['dir'] = "/var/lib/pgsql9/data"
   else
     default['postgresql']['version'] = "8.4"
@@ -155,37 +177,23 @@ when "amazon"
 when "redhat", "centos", "scientific", "oracle"
 
   default['postgresql']['version'] = "8.4"
-  default['postgresql']['dir'] = "/var/lib/pgsql/data"
+
+  default['postgresql']['client']['packages'] = ["postgresql84-devel"]
+  default['postgresql']['server']['packages'] = ["postgresql84-server"]
+  default['postgresql']['contrib']['packages'] = ["postgresql84-contrib"]
+
   default['postgresql']['setup_script'] = "postgresql-setup"
+  default['postgresql']['server']['service_name'] = "postgresql"
 
-  if node['platform_version'].to_f >= 6.0 && node['postgresql']['version'] == '8.4'
-    default['postgresql']['client']['packages'] = %w{postgresql-devel}
-    default['postgresql']['server']['packages'] = %w{postgresql-server}
-    default['postgresql']['contrib']['packages'] = %w{postgresql-contrib}
-  else
-    default['postgresql']['client']['packages'] = ["postgresql#{node['postgresql']['version'].split('.').join}-devel"]
-    default['postgresql']['server']['packages'] = ["postgresql#{node['postgresql']['version'].split('.').join}-server"]
-    default['postgresql']['contrib']['packages'] = ["postgresql#{node['postgresql']['version'].split('.').join}-contrib"]
-  end
-
-  if node['platform_version'].to_f >= 6.0 && node['postgresql']['version'] != '8.4'
-    default['postgresql']['dir'] = "/var/lib/pgsql/#{node['postgresql']['version']}/data"
-
-    if node['postgresql']['server']['init_package'] == 'systemd'
-      default['postgresql']['server']['service_name'] = "postgresql"
-    else
-      default['postgresql']['server']['service_name'] = "postgresql-#{node['postgresql']['version']}"
-    end
-
-    if node['postgresql']['version'].to_f >= 9.3
-      default['postgresql']['setup_script'] = "/usr/pgsql-#{node['postgresql']['version']}/bin/postgresql#{node['postgresql']['version'].split('.').join}-setup"
-    end
-  else
-    default['postgresql']['dir'] = "/var/lib/pgsql/data"
-    default['postgresql']['server']['service_name'] = "postgresql"
+  if node['platform_version'].to_f >= 6.0 && node['postgresql']['version'].to_f == 8.4
+    default['postgresql']['client']['packages'] = ['postgresql-devel']
+    default['postgresql']['server']['packages'] = ['postgresql-server']
+    default['postgresql']['contrib']['packages'] = ['postgresql-contrib']
   end
 
 when "opensuse"
+
+  default['postgresql']['dir'] = "/var/lib/pgsql/data"
 
   if node['platform_version'].to_f == 13.2
     default['postgresql']['version'] = '9.3'
@@ -199,11 +207,10 @@ when "opensuse"
     default['postgresql']['contrib']['packages'] = ['postgresql92-contrib']
   end
 
-  default['postgresql']['dir'] = "/var/lib/pgsql/data"
   default['postgresql']['server']['service_name'] = "postgresql"
 
 when "suse"
-    if node['platform_version'].to_f <= 11.1
+  if node['platform_version'].to_f <= 11.1
     default['postgresql']['version'] = "8.3"
     default['postgresql']['client']['packages'] = ['postgresql', 'rubygem-pg']
     default['postgresql']['server']['packages'] = ['postgresql-server']
@@ -220,46 +227,24 @@ when "suse"
 
 else
   default['postgresql']['version'] = "8.4"
-  default['postgresql']['dir']         = "/etc/postgresql/#{node['postgresql']['version']}/main"
+  default['postgresql']['dir'] = "/etc/postgresql/8.4/main"
   default['postgresql']['client']['packages'] = ["postgresql"]
   default['postgresql']['server']['packages'] = ["postgresql"]
   default['postgresql']['contrib']['packages'] = ["postgresql"]
   default['postgresql']['server']['service_name'] = "postgresql"
 end
 
-# These defaults have disparity between which postgresql configuration
-# settings are used because they were extracted from the original
-# configuration files that are now removed in favor of dynamic
-# generation.
-#
-# While the configuration ends up being the same as the default
-# in previous versions of the cookbook, the content of the rendered
-# template will change, and this will result in service notification
-# if you upgrade the cookbook on existing systems.
-#
-# The ssl config attribute is generated in the recipe to avoid awkward
-# merge/precedence order during the Chef run.
 case node['platform_family']
 when 'debian'
-  default['postgresql']['config']['data_directory'] = "/var/lib/postgresql/#{node['postgresql']['version']}/main"
-  default['postgresql']['config']['hba_file'] = "/etc/postgresql/#{node['postgresql']['version']}/main/pg_hba.conf"
-  default['postgresql']['config']['ident_file'] = "/etc/postgresql/#{node['postgresql']['version']}/main/pg_ident.conf"
-  default['postgresql']['config']['external_pid_file'] = "/var/run/postgresql/#{node['postgresql']['version']}-main.pid"
   default['postgresql']['config']['listen_addresses'] = 'localhost'
   default['postgresql']['config']['port'] = 5432
   default['postgresql']['config']['max_connections'] = 100
-  default['postgresql']['config']['unix_socket_directory'] = '/var/run/postgresql' if node['postgresql']['version'].to_f < 9.3
-  default['postgresql']['config']['unix_socket_directories'] = '/var/run/postgresql' if node['postgresql']['version'].to_f >= 9.3
   default['postgresql']['config']['shared_buffers'] = '24MB'
-  default['postgresql']['config']['max_fsm_pages'] = 153600 if node['postgresql']['version'].to_f < 8.4
   default['postgresql']['config']['log_line_prefix'] = '%t '
   default['postgresql']['config']['datestyle'] = 'iso, mdy'
   default['postgresql']['config']['default_text_search_config'] = 'pg_catalog.english'
   default['postgresql']['config']['ssl'] = true
-  default['postgresql']['config']['ssl_cert_file'] = '/etc/ssl/certs/ssl-cert-snakeoil.pem' if node['postgresql']['version'].to_f >= 9.2
-  default['postgresql']['config']['ssl_key_file'] = '/etc/ssl/private/ssl-cert-snakeoil.key'if node['postgresql']['version'].to_f >= 9.2
 when 'rhel', 'fedora', 'suse'
-  default['postgresql']['config']['data_directory'] = node['postgresql']['dir']
   default['postgresql']['config']['listen_addresses'] = 'localhost'
   default['postgresql']['config']['port'] = 5432
   default['postgresql']['config']['max_connections'] = 100
@@ -292,396 +277,5 @@ when 'debian'
   default['postgresql']['pgdg']['release_apt_codename'] = node['lsb']['codename']
 end
 
-default['postgresql']['enable_pgdg_yum'] = false
-
 default['postgresql']['initdb_locale'] = 'UTF-8'
-
-# The PostgreSQL RPM Building Project built repository RPMs for easy
-# access to the PGDG yum repositories. Links to RPMs for installation
-# on the supported version/platform combinations are listed at
-# http://yum.postgresql.org/repopackages.php, and the links for
-# PostgreSQL 8.4, 9.0, 9.1, 9.2, 9.3 and 9.4 are captured below.
-#
-# The correct RPM for installing /etc/yum.repos.d is based on:
-# * the attribute configuring the desired Postgres Software:
-#   node['postgresql']['version']        e.g., "9.1"
-# * the chef ohai description of the target Operating System:
-#   node['platform']                     e.g., "centos"
-#   node['platform_version']             e.g., "5.7", truncated as "5"
-#   node['kernel']['machine']            e.g., "i386" or "x86_64"
-default['postgresql']['pgdg']['repo_rpm_url'] = {
-  "9.4" => {
-    "redhat" => {
-      "7" => {
-        "x86_64" => "http://yum.postgresql.org/9.4/redhat/rhel-7-x86_64/pgdg-redhat94-9.4-1.noarch.rpm"
-      },
-      "6" => {
-        "i386" => "http://yum.postgresql.org/9.4/redhat/rhel-6-i386/pgdg-redhat94-9.4-1.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-redhat94-9.4-1.noarch.rpm"
-      },
-      "5" => {
-        "i386" => "http://yum.postgresql.org/9.4/redhat/rhel-5-i386/pgdg-redhat94-9.4-1.noarch.rpm",
-        "x86_64" =>  "http://yum.postgresql.org/9.4/redhat/rhel-5-x86_64/pgdg-redhat94-9.4-1.noarch.rpm"
-      }
-    },
-    "centos" => {
-      "7" => {
-        "x86_64" => "http://yum.postgresql.org/9.4/redhat/rhel-7-x86_64/pgdg-centos94-9.4-1.noarch.rpm"
-      },
-      "6" => {
-        "i386" => "http://yum.postgresql.org/9.4/redhat/rhel-6-i386/pgdg-centos94-9.4-1.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-centos94-9.4-1.noarch.rpm"
-      },
-      "5" => {
-        "x86_64" => "http://yum.postgresql.org/9.4/redhat/rhel-5-x86_64/pgdg-centos94-9.4-1.noarch.rpm",
-        "i386" => "http://yum.postgresql.org/9.4/redhat/rhel-5-i386/pgdg-centos94-9.4-1.noarch.rpm"
-      }
-    },
-    "fedora" => {
-      "22" => {
-        "x86_64" => "http://yum.postgresql.org/9.4/fedora/fedora-22-x86_64/pgdg-fedora94-9.4-3.noarch.rpm"
-      },
-      "21" => {
-        "x86_64" => "http://yum.postgresql.org/9.4/fedora/fedora-21-x86_64/pgdg-fedora94-9.4-2.noarch.rpm",
-        "i386" => "http://yum.postgresql.org/9.4/fedora/fedora-21-i686/pgdg-fedora94-9.4-2.noarch.rpm"
-      },
-      "20" => {
-        "x86_64" => "http://yum.postgresql.org/9.4/fedora/fedora-20-x86_64/pgdg-fedora94-9.4-1.noarch.rpm",
-        "i386" => "http://yum.postgresql.org/9.4/fedora/fedora-20-i686/pgdg-fedora94-9.4-1.noarch.rpm"
-      }
-    },
-    "amazon" => {
-      "2015" => {
-        "i386" => "http://yum.postgresql.org/9.4/redhat/rhel-6-i386/pgdg-ami201503-94-9.4-1.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-ami201503-94-9.4-1.noarch.rpm"
-      }
-    },
-    "scientific" => {
-      "7" => {
-        "x86_64" => "http://yum.postgresql.org/9.4/redhat/rhel-7-x86_64/pgdg-sl94-9.4-1.noarch.rpm"
-      },
-      "6" => {
-        "i386" => "http://yum.postgresql.org/9.4/redhat/rhel-6-i386/pgdg-sl94-9.4-1.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-sl94-9.4-1.noarch.rpm"
-      },
-      "5" => {
-        "i386" => "http://yum.postgresql.org/9.4/redhat/rhel-5-i386/pgdg-sl94-9.4-1.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.4/redhat/rhel-5-x86_64/pgdg-sl94-9.4-1.noarch.rpm"
-      }
-    },
-    "oracle" => {
-      "7" => {
-        "x86_64" => "http://yum.postgresql.org/9.4/redhat/rhel-7-x86_64/pgdg-oraclelinux94-9.4-1.noarch.rpm"
-      },
-      "6" => {
-        "i386" => "http://yum.postgresql.org/9.4/redhat/rhel-6-i386/pgdg-oraclelinux94-9.4-1.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-oraclelinux94-9.4-1.noarch.rpm"
-      }
-    }
-  },
-  "9.3" => {
-    "amazon" => {
-      "2015" => {
-        "i386" => "http://yum.postgresql.org/9.3/redhat/rhel-6-i386/pgdg-redhat93-9.3-1.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.3/redhat/rhel-6-x86_64/pgdg-redhat93-9.3-1.noarch.rpm"
-      },
-      "2014" => {
-        "i386" => "http://yum.postgresql.org/9.3/redhat/rhel-6-i386/pgdg-redhat93-9.3-1.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.3/redhat/rhel-6-x86_64/pgdg-redhat93-9.3-1.noarch.rpm"
-      },
-      "2013" => {
-        "i386" => "http://yum.postgresql.org/9.3/redhat/rhel-6-i386/pgdg-redhat93-9.3-1.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.3/redhat/rhel-6-x86_64/pgdg-redhat93-9.3-1.noarch.rpm"
-      }
-    },
-    "centos" => {
-      "7" => {
-        "x86_64" => "http://yum.postgresql.org/9.3/redhat/rhel-7-x86_64/pgdg-centos93-9.3-1.noarch.rpm"
-      },
-      "6" => {
-        "i386" => "http://yum.postgresql.org/9.3/redhat/rhel-6-i386/pgdg-centos93-9.3-1.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.3/redhat/rhel-6-x86_64/pgdg-centos93-9.3-1.noarch.rpm"
-      },
-      "5" => {
-        "i386" => "http://yum.postgresql.org/9.3/redhat/rhel-5-i386/pgdg-centos93-9.3-1.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.3/redhat/rhel-5-x86_64/pgdg-centos93-9.3-1.noarch.rpm"
-      }
-    },
-    "redhat" => {
-      "7" => {
-         "x86_64" => "http://yum.postgresql.org/9.3/redhat/rhel-7-x86_64/pgdg-redhat93-9.3-1.noarch.rpm"
-      },
-      "6" => {
-        "i386" => "http://yum.postgresql.org/9.3/redhat/rhel-6-i386/pgdg-redhat93-9.3-1.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.3/redhat/rhel-6-x86_64/pgdg-redhat93-9.3-1.noarch.rpm"
-      },
-      "5" => {
-        "i386" => "http://yum.postgresql.org/9.3/redhat/rhel-5-i386/pgdg-redhat93-9.3-1.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.3/redhat/rhel-5-x86_64/pgdg-redhat93-9.3-1.noarch.rpm"
-      }
-    },
-    "oracle" => {
-      "6" => {
-        "i386" => "http://yum.postgresql.org/9.3/redhat/rhel-6-i386/pgdg-redhat93-9.3-1.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.3/redhat/rhel-6-x86_64/pgdg-redhat93-9.3-1.noarch.rpm"
-      },
-      "5" => {
-        "i386" => "http://yum.postgresql.org/9.3/redhat/rhel-5-i386/pgdg-redhat93-9.3-1.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.3/redhat/rhel-5-x86_64/pgdg-redhat93-9.3-1.noarch.rpm"
-      }
-    },
-    "scientific" => {
-      "6" => {
-        "i386" => "http://yum.postgresql.org/9.3/redhat/rhel-6-i386/pgdg-sl93-9.3-1.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.3/redhat/rhel-6-x86_64/pgdg-sl93-9.3-1.noarch.rpm"
-      },
-      "5" => {
-        "i386" => "http://yum.postgresql.org/9.3/redhat/rhel-5-i386/pgdg-sl93-9.3-1.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.3/redhat/rhel-5-x86_64/pgdg-sl93-9.3-1.noarch.rpm"
-      }
-    },
-    "fedora" => {
-      "20" => {
-        "x86_64" => "http://yum.postgresql.org/9.3/fedora/fedora-20-x86_64/pgdg-fedora93-9.3-1.noarch.rpm"
-      },
-      "19" => {
-        "x86_64" => "http://yum.postgresql.org/9.3/fedora/fedora-19-x86_64/pgdg-fedora93-9.3-1.noarch.rpm"
-      },
-      "18" => {
-        "i386" => "http://yum.postgresql.org/9.3/fedora/fedora-18-i386/pgdg-fedora93-9.3-1.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.3/fedora/fedora-18-x86_64/pgdg-fedora93-9.3-1.noarch.rpm"
-      },
-      "17" => {
-        "i386" => "http://yum.postgresql.org/9.3/fedora/fedora-17-i386/pgdg-fedora93-9.3-1.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.3/fedora/fedora-17-x86_64/pgdg-fedora93-9.3-1.noarch.rpm"
-      }
-    }
-  },
-  "9.2" => {
-    "centos" => {
-      "6" => {
-        "i386" => "http://yum.postgresql.org/9.2/redhat/rhel-6-i386/pgdg-centos92-9.2-7.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.2/redhat/rhel-6-x86_64/pgdg-centos92-9.2-7.noarch.rpm"
-      },
-      "5" => {
-        "i386" => "http://yum.postgresql.org/9.2/redhat/rhel-5-i386/pgdg-centos92-9.2-7.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.2/redhat/rhel-5-x86_64/pgdg-centos92-9.2-7.noarch.rpm"
-      }
-    },
-    "redhat" => {
-      "6" => {
-        "i386" => "http://yum.postgresql.org/9.2/redhat/rhel-6-i386/pgdg-redhat92-9.2-7.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.2/redhat/rhel-6-x86_64/pgdg-redhat92-9.2-7.noarch.rpm"
-      },
-      "5" => {
-        "i386" => "http://yum.postgresql.org/9.2/redhat/rhel-5-i386/pgdg-redhat92-9.2-7.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.2/redhat/rhel-5-x86_64/pgdg-redhat92-9.2-7.noarch.rpm"
-      }
-    },
-    "oracle" => {
-      "6" => {
-        "i386" => "http://yum.postgresql.org/9.2/redhat/rhel-6-i386/pgdg-redhat92-9.2-7.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.2/redhat/rhel-6-x86_64/pgdg-redhat92-9.2-7.noarch.rpm"
-      },
-      "5" => {
-        "i386" => "http://yum.postgresql.org/9.2/redhat/rhel-5-i386/pgdg-redhat92-9.2-7.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.2/redhat/rhel-5-x86_64/pgdg-redhat92-9.2-7.noarch.rpm"
-      }
-    },
-    "scientific" => {
-      "6" => {
-        "i386" => "http://yum.postgresql.org/9.2/redhat/rhel-6-i386/pgdg-sl92-9.2-8.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.2/redhat/rhel-6-x86_64/pgdg-sl92-9.2-8.noarch.rpm"
-      },
-      "5" => {
-        "i386" => "http://yum.postgresql.org/9.2/redhat/rhel-5-i386/pgdg-sl92-9.2-8.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.2/redhat/rhel-5-x86_64/pgdg-sl92-9.2-8.noarch.rpm"
-      }
-    },
-    "fedora" => {
-      "19" => {
-        "i386" => "http://yum.postgresql.org/9.2/fedora/fedora-19-i386/pgdg-fedora92-9.2-6.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.2/fedora/fedora-19-x86_64/pgdg-fedora92-9.2-6.noarch.rpm"
-      },
-      "18" => {
-        "i386" => "http://yum.postgresql.org/9.2/fedora/fedora-18-i386/pgdg-fedora92-9.2-6.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.2/fedora/fedora-18-x86_64/pgdg-fedora92-9.2-6.noarch.rpm"
-      },
-      "17" => {
-        "i386" => "http://yum.postgresql.org/9.2/fedora/fedora-17-i386/pgdg-fedora92-9.2-6.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.2/fedora/fedora-17-x86_64/pgdg-fedora92-9.2-5.noarch.rpm"
-      },
-      "16" => {
-        "i386" => "http://yum.postgresql.org/9.2/fedora/fedora-16-i386/pgdg-fedora92-9.2-5.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.2/fedora/fedora-16-x86_64/pgdg-fedora92-9.2-5.noarch.rpm"
-      }
-    }
-  },
-  "9.1" => {
-    "centos" => {
-      "6" => {
-        "i386" => "http://yum.postgresql.org/9.1/redhat/rhel-6-i386/pgdg-centos91-9.1-4.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.1/redhat/rhel-5-x86_64/pgdg-centos91-9.1-4.noarch.rpm"
-      },
-      "5" => {
-        "i386" => "http://yum.postgresql.org/9.1/redhat/rhel-5-i386/pgdg-centos91-9.1-4.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.1/redhat/rhel-5-x86_64/pgdg-centos91-9.1-4.noarch.rpm"
-      },
-      "4" => {
-        "i386" => "http://yum.postgresql.org/9.1/redhat/rhel-4-i386/pgdg-centos91-9.1-4.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.1/redhat/rhel-4-x86_64/pgdg-centos91-9.1-4.noarch.rpm"
-      }
-    },
-    "redhat" => {
-      "6" => {
-        "i386" => "http://yum.postgresql.org/9.1/redhat/rhel-6-i386/pgdg-redhat91-9.1-5.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.1/redhat/rhel-6-x86_64/pgdg-redhat91-9.1-5.noarch.rpm"
-      },
-      "5" => {
-        "i386" => "http://yum.postgresql.org/9.1/redhat/rhel-5-i386/pgdg-redhat91-9.1-5.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.1/redhat/rhel-5-x86_64/pgdg-redhat91-9.1-5.noarch.rpm"
-      },
-      "4" => {
-        "i386" => "http://yum.postgresql.org/9.1/redhat/rhel-4-i386/pgdg-redhat-9.1-4.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.1/redhat/rhel-4-x86_64/pgdg-redhat-9.1-4.noarch.rpm"
-      }
-    },
-    "scientific" => {
-      "6" => {
-        "i386" => "http://yum.postgresql.org/9.1/redhat/rhel-6-i386/pgdg-sl91-9.1-6.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.1/redhat/rhel-6-x86_64/pgdg-sl91-9.1-6.noarch.rpm"
-      },
-      "5" => {
-        "i386" => "http://yum.postgresql.org/9.1/redhat/rhel-5-i386/pgdg-sl91-9.1-6.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.1/redhat/rhel-5-x86_64/pgdg-sl91-9.1-6.noarch.rpm"
-      }
-    },
-    "fedora" => {
-      "16" => {
-        "i386" => "http://yum.postgresql.org/9.1/fedora/fedora-16-i386/pgdg-fedora91-9.1-4.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.1/fedora/fedora-16-x86_64/pgdg-fedora91-9.1-4.noarch.rpm"
-      },
-      "15" => {
-        "i386" => "http://yum.postgresql.org/9.1/fedora/fedora-15-i386/pgdg-fedora91-9.1-4.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.1/fedora/fedora-15-x86_64/pgdg-fedora91-9.1-4.noarch.rpm"
-      },
-      "14" => {
-        "i386" => "http://yum.postgresql.org/9.1/fedora/fedora-14-i386/pgdg-fedora91-9.1-4.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.1/fedora/fedora-14-x86_64/pgdg-fedora-9.1-2.noarch.rpm"
-      }
-    }
-  },
-  "9.0" => {
-    "centos" => {
-      "6" => {
-        "i386" => "http://yum.postgresql.org/9.0/redhat/rhel-6-i386/pgdg-centos90-9.0-5.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.0/redhat/rhel-6-x86_64/pgdg-centos90-9.0-5.noarch.rpm"
-      },
-      "5" => {
-        "i386" => "http://yum.postgresql.org/9.0/redhat/rhel-5-i386/pgdg-centos90-9.0-5.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.0/redhat/rhel-5-x86_64/pgdg-centos90-9.0-5.noarch.rpm"
-      },
-      "4" => {
-        "i386" => "http://yum.postgresql.org/9.0/redhat/rhel-4-i386/pgdg-centos90-9.0-5.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.0/redhat/rhel-4-x86_64/pgdg-centos90-9.0-5.noarch.rpm"
-      }
-    },
-    "redhat" => {
-      "6" => {
-        "i386" => "http://yum.postgresql.org/9.0/redhat/rhel-6-i386/pgdg-redhat90-9.0-5.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.0/redhat/rhel-6-x86_64/pgdg-redhat90-9.0-5.noarch.rpm"
-      },
-      "5" => {
-        "i386" => "http://yum.postgresql.org/9.0/redhat/rhel-5-i386/pgdg-redhat90-9.0-5.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.0/redhat/rhel-5-x86_64/pgdg-redhat90-9.0-5.noarch.rpm"
-      },
-      "4" => {
-        "i386" => "http://yum.postgresql.org/9.0/redhat/rhel-4-i386/pgdg-redhat90-9.0-5.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.0/redhat/rhel-4-x86_64/pgdg-redhat90-9.0-5.noarch.rpm"
-      }
-    },
-    "scientific" => {
-      "6" => {
-        "i386" => "http://yum.postgresql.org/9.0/redhat/rhel-6-i386/pgdg-sl90-9.0-6.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.0/redhat/rhel-6-x86_64/pgdg-sl90-9.0-6.noarch.rpm"
-      },
-      "5" => {
-        "i386" => "http://yum.postgresql.org/9.0/redhat/rhel-5-i386/pgdg-sl90-9.0-6.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.0/redhat/rhel-5-x86_64/pgdg-sl90-9.0-6.noarch.rpm"
-      }
-    },
-    "fedora" => {
-      "15" => {
-        "i386" => "http://yum.postgresql.org/9.0/fedora/fedora-15-i386/pgdg-fedora90-9.0-5.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.0/fedora/fedora-15-x86_64/pgdg-fedora90-9.0-5.noarch.rpm"
-      },
-      "14" => {
-        "i386" => "http://yum.postgresql.org/9.0/fedora/fedora-14-i386/pgdg-fedora90-9.0-5.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/9.0/fedora/fedora-14-x86_64/pgdg-fedora90-9.0-5.noarch.rpm"
-      }
-    }
-  },
-  "8.4" => {
-    "centos" => {
-      "6" => {
-        "i386" => "http://yum.postgresql.org/8.4/redhat/rhel-6-i386/pgdg-centos-8.4-3.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/8.4/redhat/rhel-6-x86_64/pgdg-centos-8.4-3.noarch.rpm"
-      },
-      "5" => {
-        "i386" => "http://yum.postgresql.org/8.4/redhat/rhel-5-i386/pgdg-centos-8.4-3.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/8.4/redhat/rhel-5-x86_64/pgdg-centos-8.4-3.noarch.rpm"
-      },
-      "4" => {
-        "i386" => "http://yum.postgresql.org/8.4/redhat/rhel-4-i386/pgdg-centos-8.4-3.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/8.4/redhat/rhel-4-x86_64/pgdg-centos-8.4-3.noarch.rpm"
-      }
-    },
-    "redhat" => {
-      "6" => {
-        "i386" => "http://yum.postgresql.org/8.4/redhat/rhel-6-i386/pgdg-redhat-8.4-3.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/8.4/redhat/rhel-6-x86_64/pgdg-redhat-8.4-3.noarch.rpm"
-      },
-      "5" => {
-        "i386" => "http://yum.postgresql.org/8.4/redhat/rhel-5-i386/pgdg-redhat-8.4-3.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/8.4/redhat/rhel-5-x86_64/pgdg-redhat-8.4-3.noarch.rpm"
-      },
-      "4" => {
-        "i386" => "http://yum.postgresql.org/8.4/redhat/rhel-4-i386/pgdg-redhat-8.4-3.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/8.4/redhat/rhel-4-x86_64/pgdg-redhat-8.4-3.noarch.rpm"
-      }
-    },
-    "scientific" => {
-      "6" => {
-        "i386" => "http://yum.postgresql.org/8.4/redhat/rhel-6-i386/pgdg-sl84-8.4-4.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/8.4/redhat/rhel-6-x86_64/pgdg-sl84-8.4-4.noarch.rpm"
-      },
-      "5" => {
-        "i386" => "http://yum.postgresql.org/8.4/redhat/rhel-5-i386/pgdg-sl-8.4-4.noarch.rpm",
-        "x86_64" => "http://yum.postgresql.org/8.4/redhat/rhel-5-x86_64/pgdg-sl-8.4-4.noarch.rpm"
-      }
-    },
-    "fedora" => {
-      "14" => {
-        "i386" => "http://yum.postgresql.org/8.4/fedora/fedora-14-i386/",
-        "x86_64" => "http://yum.postgresql.org/8.4/fedora/fedora-14-x86_64/"
-      },
-      "13" => {
-        "i386" => "http://yum.postgresql.org/8.4/fedora/fedora-13-i386/",
-        "x86_64" => "http://yum.postgresql.org/8.4/fedora/fedora-13-x86_64/"
-      },
-      "12" => {
-        "i386" => "http://yum.postgresql.org/8.4/fedora/fedora-12-i386/",
-        "x86_64" => "http://yum.postgresql.org/8.4/fedora/fedora-12-x86_64/"
-      },
-      "8" => {
-        "i386" => "http://yum.postgresql.org/8.4/fedora/fedora-8-i386/",
-        "x86_64" => "http://yum.postgresql.org/8.4/fedora/fedora-8-x86_64/"
-      },
-      "7" => {
-        "i386" => "http://yum.postgresql.org/8.4/fedora/fedora-7-i386/",
-        "x86_64" => "http://yum.postgresql.org/8.4/fedora/fedora-7-x86_64/"
-      }
-    }
-  },
-};
 

--- a/attributes/yum_pgdg_packages.rb
+++ b/attributes/yum_pgdg_packages.rb
@@ -1,0 +1,452 @@
+# The PostgreSQL RPM Building Project built repository RPMs for easy
+# access to the PGDG yum repositories. Links to RPMs for installation
+# on the supported version/platform combinations are listed at
+# http://yum.postgresql.org/repopackages.php, and the links for
+# PostgreSQL 9.2, 9.3 and 9.4 are captured below.
+#
+default['postgresql']['pgdg']['repo_rpm_url'] = {
+  "9.4" => {
+    "redhat" => {
+      "7" => {
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-7-x86_64/",
+          "package" => "pgdg-redhat94-9.4-1.noarch.rpm"
+        }
+      },
+      "6" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-6-i386/",
+          "package" => "pgdg-redhat94-9.4-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/",
+          "package" => "pgdg-redhat94-9.4-1.noarch.rpm"
+        }
+      },
+      "5" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-5-i386/",
+          "package" => "pgdg-redhat94-9.4-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-5-x86_64/",
+          "package" => "pgdg-redhat94-9.4-1.noarch.rpm"
+        }
+      }
+    },
+    "centos" => {
+      "7" => {
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-7-x86_64/",
+          "package" => "pgdg-centos94-9.4-1.noarch.rpm"
+        }
+      },
+      "6" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-6-i386/",
+          "package" => "pgdg-centos94-9.4-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/",
+          "package" => "pgdg-centos94-9.4-1.noarch.rpm"
+        }
+      },
+      "5" => {
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-5-x86_64/",
+          "package" => "pgdg-centos94-9.4-1.noarch.rpm"
+        },
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-5-i386/",
+          "package" => "pgdg-centos94-9.4-1.noarch.rpm"
+        }
+      }
+    },
+    "fedora" => {
+      "22" => {
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.4/fedora/fedora-22-x86_64/",
+          "package" => "pgdg-fedora94-9.4-3.noarch.rpm"
+        }
+      },
+      "21" => {
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.4/fedora/fedora-21-x86_64/",
+          "package" => "pgdg-fedora94-9.4-2.noarch.rpm"
+      },
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.4/fedora/fedora-21-i686/",
+          "package" => "pgdg-fedora94-9.4-2.noarch.rpm"
+        }
+      },
+      "20" => {
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.4/fedora/fedora-20-x86_64/",
+          "package" => "pgdg-fedora94-9.4-1.noarch.rpm"
+        },
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.4/fedora/fedora-20-i686/",
+          "package" => "pgdg-fedora94-9.4-1.noarch.rpm"
+        }
+      }
+    },
+    "amazon" => {
+      "2015" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-6-i386/",
+          "package" => "pgdg-ami201503-94-9.4-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/",
+          "package" => "pgdg-ami201503-94-9.4-1.noarch.rpm"
+        }
+      }
+    },
+    "scientific" => {
+      "7" => {
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-7-x86_64/",
+          "package" => "pgdg-sl94-9.4-1.noarch.rpm"
+        }
+      },
+      "6" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-6-i386/",
+          "package" => "pgdg-sl94-9.4-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/",
+          "package" => "pgdg-sl94-9.4-1.noarch.rpm"
+        }
+      },
+      "5" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-5-i386/",
+          "package" => "pgdg-sl94-9.4-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-5-x86_64/",
+          "package" => "pgdg-sl94-9.4-1.noarch.rpm"
+        }
+      }
+    },
+    "oracle" => {
+      "7" => {
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-7-x86_64/",
+          "package" => "pgdg-oraclelinux94-9.4-1.noarch.rpm"
+        }
+      },
+      "6" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-6-i386/",
+          "package" => "pgdg-oraclelinux94-9.4-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/",
+          "package" => "pgdg-oraclelinux94-9.4-1.noarch.rpm"
+        }
+      }
+    }
+  },
+  "9.3" => {
+    "amazon" => {
+      "2015" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-i386/",
+          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-x86_64/",
+          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+        }
+      },
+      "2014" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-i386/",
+          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-x86_64/",
+          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+        }
+      },
+      "2013" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-i386/",
+          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-x86_64/",
+          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+        }
+      }
+    },
+    "centos" => {
+      "7" => {
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-7-x86_64/",
+          "package" => "pgdg-centos93-9.3-1.noarch.rpm"
+        }
+      },
+      "6" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-i386/",
+          "package" => "pgdg-centos93-9.3-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-x86_64/",
+          "package" => "pgdg-centos93-9.3-1.noarch.rpm"
+        }
+      },
+      "5" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-5-i386/",
+          "package" => "pgdg-centos93-9.3-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-5-x86_64/",
+          "package" => "pgdg-centos93-9.3-1.noarch.rpm"
+        }
+      }
+    },
+    "redhat" => {
+      "7" => {
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-7-x86_64/",
+          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+        }
+      },
+      "6" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-i386/",
+          "package" => "pgdg-redhat93-9.3-1.noarch.rpm",
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-x86_64/",
+          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+        }
+      },
+      "5" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-5-i386/",
+          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-5-x86_64/",
+          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+        }
+      }
+    },
+    "oracle" => {
+      "6" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-i386/",
+          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-x86_64/",
+          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+        }
+      },
+      "5" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-5-i386/",
+          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-5-x86_64/",
+          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+        }
+      }
+    },
+    "scientific" => {
+      "6" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-i386/",
+          "package" => "pgdg-sl93-9.3-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-x86_64/",
+          "package" => "pgdg-sl93-9.3-1.noarch.rpm"
+        }
+      },
+      "5" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-5-i386/",
+          "package" => "pgdg-sl93-9.3-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.3/redhat/rhel-5-x86_64/",
+          "package" => "pgdg-sl93-9.3-1.noarch.rpm"
+        }
+      }
+    },
+    "fedora" => {
+      "20" => {
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.3/fedora/fedora-20-x86_64/",
+          "pakcage" => "pgdg-fedora93-9.3-1.noarch.rpm"
+        }
+      },
+      "19" => {
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.3/fedora/fedora-19-x86_64/",
+          "pakcage" => "pgdg-fedora93-9.3-1.noarch.rpm"
+        }
+      },
+      "18" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.3/fedora/fedora-18-i386/",
+          "package" => "pgdg-fedora93-9.3-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.3/fedora/fedora-18-x86_64/",
+          "package" => "pgdg-fedora93-9.3-1.noarch.rpm"
+        }
+      },
+      "17" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.3/fedora/fedora-17-i386/",
+          "package" => "pgdg-fedora93-9.3-1.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.3/fedora/fedora-17-x86_64/",
+          "package" => "pgdg-fedora93-9.3-1.noarch.rpm"
+        }
+      }
+    }
+  },
+  "9.2" => {
+    "centos" => {
+      "6" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.2/redhat/rhel-6-i386/",
+          "package" => "pgdg-centos92-9.2-7.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.2/redhat/rhel-6-x86_64/",
+          "package" => "pgdg-centos92-9.2-7.noarch.rpm"
+        }
+      },
+      "5" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.2/redhat/rhel-5-i386/",
+          "package" => "pgdg-centos92-9.2-7.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.2/redhat/rhel-5-x86_64/",
+          "package" => "pgdg-centos92-9.2-7.noarch.rpm"
+        }
+      }
+    },
+    "redhat" => {
+      "6" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.2/redhat/rhel-6-i386/",
+          "package" => "pgdg-redhat92-9.2-7.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.2/redhat/rhel-6-x86_64/",
+          "package" => "pgdg-redhat92-9.2-7.noarch.rpm"
+        }
+      },
+      "5" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.2/redhat/rhel-5-i386/",
+          "package" => "pgdg-redhat92-9.2-7.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.2/redhat/rhel-5-x86_64/",
+          "package" => "pgdg-redhat92-9.2-7.noarch.rpm"
+        }
+      }
+    },
+    "oracle" => {
+      "6" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.2/redhat/rhel-6-i386/",
+          "package" => "pgdg-redhat92-9.2-7.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.2/redhat/rhel-6-x86_64/",
+          "package" => "pgdg-redhat92-9.2-7.noarch.rpm"
+        }
+      },
+      "5" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.2/redhat/rhel-5-i386/",
+          "package" => "pgdg-redhat92-9.2-7.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.2/redhat/rhel-5-x86_64/",
+          "package" => "pgdg-redhat92-9.2-7.noarch.rpm"
+        }
+      }
+    },
+    "scientific" => {
+      "6" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.2/redhat/rhel-6-i386/",
+          "package" => "pgdg-sl92-9.2-8.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.2/redhat/rhel-6-x86_64/",
+          "package" => "pgdg-sl92-9.2-8.noarch.rpm"
+        }
+      },
+      "5" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.2/redhat/rhel-5-i386/",
+          "package" => "pgdg-sl92-9.2-8.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.2/redhat/rhel-5-x86_64/",
+          "package" => "pgdg-sl92-9.2-8.noarch.rpm"
+        }
+      }
+    },
+    "fedora" => {
+      "19" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.2/fedora/fedora-19-i386/",
+          "package" => "pgdg-fedora92-9.2-6.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.2/fedora/fedora-19-x86_64/",
+          "package" => "pgdg-fedora92-9.2-6.noarch.rpm"
+        }
+      },
+      "18" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.2/fedora/fedora-18-i386/",
+          "package" => "pgdg-fedora92-9.2-6.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.2/fedora/fedora-18-x86_64/",
+          "package" => "pgdg-fedora92-9.2-6.noarch.rpm"
+        }
+      },
+      "17" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.2/fedora/fedora-17-i386/",
+          "package" => "pgdg-fedora92-9.2-6.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.2/fedora/fedora-17-x86_64/",
+          "package" => "pgdg-fedora92-9.2-5.noarch.rpm"
+        }
+      },
+      "16" => {
+        "i386" => {
+          "url" => "http://yum.postgresql.org/9.2/fedora/fedora-16-i386/",
+          "package" => "pgdg-fedora92-9.2-5.noarch.rpm"
+        },
+        "x86_64" => {
+          "url" => "http://yum.postgresql.org/9.2/fedora/fedora-16-x86_64/",
+          "package" => "pgdg-fedora92-9.2-5.noarch.rpm"
+        }
+      }
+    }
+  }
+}

--- a/files/default/tests/minitest/apt_pgdg_postgresql_test.rb
+++ b/files/default/tests/minitest/apt_pgdg_postgresql_test.rb
@@ -28,12 +28,12 @@ describe 'postgresql::apt_pgdg_postgresql' do
     file("/etc/apt/sources.list.d/apt.postgresql.org.list").must_exist
   end
 
-  it 'installs postgresql-client-9.3' do
-    package("postgresql-client-9.3").must_be_installed
+  it 'installs postgresql-client-9.4' do
+    package("postgresql-client-9.4").must_be_installed
   end
 
-  it 'makes psql version 9.3 available' do
+  it 'makes psql version 9.4 available' do
     psql = shell_out("psql --version")
-    assert psql.stdout.include?("psql (PostgreSQL) 9.3")
+    assert psql.stdout.include?("psql (PostgreSQL) 9.4")
   end
 end

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -348,30 +348,6 @@ def extension_installed?(pg_ext)
   end
 end
 
-######################################
-# Function to build information needed to install RPM for PGDG yum repository,
-# since PGDG supports several versions of PostgreSQL, platforms, platform versions
-# and architectures.
-# Links to RPMs for installation are in an attribute so that new versions/platforms
-# can be more easily added. (See attributes/default.rb)
-def pgdgrepo_rpm_info
-  repo_rpm_url = node['postgresql']['pgdg']['repo_rpm_url'].
-    fetch(node['postgresql']['version']).            # e.g., fetch for "9.1"
-    fetch(node['platform']).                         # e.g., fetch for "centos"
-    fetch(node['platform_version'].to_f.to_i.to_s).  # e.g., fetch for "5" (truncated "5.7")
-    fetch(node['kernel']['machine'])                 # e.g., fetch for "i386" or "x86_64"
-
-  # Extract the filename portion from the URL for the PGDG repository RPM.
-  # E.g., repo_rpm_filename = "pgdg-centos92-9.2-6.noarch.rpm"
-  repo_rpm_filename = File.basename(repo_rpm_url)
-
-  # Extract the package name from the URL for the PGDG repository RPM.
-  # E.g., repo_rpm_package = "pgdg-centos92"
-  repo_rpm_package = repo_rpm_filename.split(/-/,3)[0..1].join('-')
-
-  return [ repo_rpm_url, repo_rpm_filename, repo_rpm_package ]
-end
-
 # End the Opscode::PostgresqlHelpers module
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "support@hw-ops.com"
 license           "Apache 2.0"
 description       "Installs and configures postgresql for clients or servers"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "3.4.24"
+version           "3.4.25"
 recipe            "postgresql", "Includes postgresql::client"
 recipe            "postgresql::ruby", "Installs pg gem for Ruby bindings"
 recipe            "postgresql::client", "Installs postgresql client package(s)"

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,10 +1,10 @@
 name              "postgresql"
 maintainer        "Heavy Water Operations, LLC"
-maintainer_email  "support@hw-ops.com"
+maintainer_email  "helpdesk@heavywater.io"
 license           "Apache 2.0"
 description       "Installs and configures postgresql for clients or servers"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "3.4.25"
+version           "4.0.0"
 recipe            "postgresql", "Includes postgresql::client"
 recipe            "postgresql::ruby", "Installs pg gem for Ruby bindings"
 recipe            "postgresql::client", "Installs postgresql client package(s)"

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -17,18 +17,21 @@
 
 include_recipe "postgresql::ca_certificates"
 
-if platform_family?('debian') && node['postgresql']['version'].to_f > 9.3
-  node.default['postgresql']['enable_pgdg_apt'] = true
+case node['platform_family']
+when 'debian'
+  if node['postgresql']['version'].to_f > 9.3
+    node.set['postgresql']['enable_pgdg_apt'] = true
+  end
+
+  if node['postgresql']['enable_pgdg_apt']
+    include_recipe 'postgresql::apt_pgdg_postgresql'
+  end
+when 'rhel'
+  if node['postgresql']['enable_pgdg_yum']
+    include_recipe 'postgresql::yum_pgdg_postgresql'
+  end
 end
 
-if(node['postgresql']['enable_pgdg_apt']) and platform_family?('debian')
-  include_recipe 'postgresql::apt_pgdg_postgresql'
-end
-
-if(node['postgresql']['enable_pgdg_yum']) and platform_family?('rhel')
-  include_recipe 'postgresql::yum_pgdg_postgresql'
-end
-
-node['postgresql']['client']['packages'].each do |pg_pack|
-  package pg_pack
+node['postgresql']['client']['packages'].each do |pkg|
+  package pkg
 end

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -52,10 +52,16 @@ end
 # Include the right "family" recipe for installing the server
 # since they do things slightly differently.
 case node['platform_family']
-when "rhel", "fedora", "suse"
+when "rhel", "fedora"
+  node.set['postgresql']['dir'] = "/var/lib/pgsql/#{node['postgresql']['version']}/data"
+  node.set['postgresql']['config']['data_directory'] = "/var/lib/pgsql/#{node['postgresql']['version']}/data"
   include_recipe "postgresql::server_redhat"
 when "debian"
+  node.set['postgresql']['config']['data_directory'] = "/var/lib/postgresql/#{node['postgresql']['version']}/main"
   include_recipe "postgresql::server_debian"
+when 'suse'
+  node.set['postgresql']['config']['data_directory'] = node['postgresql']['dir']
+  include_recipe "postgresql::server_redhat"
 end
 
 # Versions prior to 9.2 do not have a config file option to set the SSL
@@ -83,7 +89,7 @@ end
 bash "assign-postgres-password" do
   user 'postgres'
   code <<-EOH
-  echo "ALTER ROLE postgres ENCRYPTED PASSWORD '#{node['postgresql']['password']['postgres']}';" | psql -p #{node['postgresql']['config']['port']}
+  echo "ALTER ROLE postgres ENCRYPTED PASSWORD \'#{node['postgresql']['password']['postgres']}\';" | psql -p #{node['postgresql']['config']['port']}
   EOH
   action :run
   not_if "ls #{node['postgresql']['config']['data_directory']}/recovery.conf"

--- a/recipes/server_conf.rb
+++ b/recipes/server_conf.rb
@@ -17,6 +17,28 @@
 
 change_notify = node['postgresql']['server']['config_change_notify']
 
+# There are some configuration items which depend on correctly evaluating the intended version being installed
+if node['platform_family'] == 'debian'
+
+  node.set['postgresql']['config']['hba_file'] = "/etc/postgresql/#{node['postgresql']['version']}/main/pg_hba.conf"
+  node.set['postgresql']['config']['ident_file'] = "/etc/postgresql/#{node['postgresql']['version']}/main/pg_ident.conf"
+  node.set['postgresql']['config']['external_pid_file'] = "/var/run/postgresql/#{node['postgresql']['version']}-main.pid"
+
+  if node['postgresql']['version'].to_f < 9.3
+    node.set['postgresql']['config']['unix_socket_directory'] = '/var/run/postgresql'
+  else
+    node.set['postgresql']['config']['unix_socket_directories'] = '/var/run/postgresql'
+  end
+
+  node.set['postgresql']['config']['max_fsm_pages'] = 153600 if node['postgresql']['version'].to_f < 8.4
+
+  if node['postgresql']['config']['ssl']
+    node.set['postgresql']['config']['ssl_cert_file'] = '/etc/ssl/certs/ssl-cert-snakeoil.pem' if node['postgresql']['version'].to_f >= 9.2
+    node.set['postgresql']['config']['ssl_key_file'] = '/etc/ssl/private/ssl-cert-snakeoil.key'if node['postgresql']['version'].to_f >= 9.2
+  end
+
+end
+
 template "#{node['postgresql']['dir']}/postgresql.conf" do
   source "postgresql.conf.erb"
   owner "postgres"

--- a/recipes/server_redhat.rb
+++ b/recipes/server_redhat.rb
@@ -18,7 +18,6 @@
 include_recipe "postgresql::client"
 
 svc_name = node['postgresql']['server']['service_name']
-dir = node['postgresql']['dir']
 initdb_locale = node['postgresql']['initdb_locale']
 
 shortver = node['postgresql']['version'].split('.').join
@@ -40,7 +39,7 @@ user "postgres" do
   supports :manage_home => false
 end
 
-directory dir do
+directory node['postgresql']['config']['data_directory'] do
   owner "postgres"
   group "postgres"
   recursive true
@@ -67,8 +66,6 @@ if node['postgresql']['enable_pgdg_yum'] == true
   end
 end
 
-# Starting with Fedora 16, the pgsql sysconfig files are no longer used,
-# its use is discouraged if using systemd
 # The systemd unit file does not support 'initdb' or 'upgrade' actions.
 # Use the postgresql-setup script instead.
 
@@ -90,14 +87,28 @@ end
 
 if node['postgresql']['server']['init_package'] == 'systemd'
 
-  execute "#{node['postgresql']['setup_script']} initdb #{svc_name}" do
-    not_if { ::FileTest.exist?(File.join(dir, "PG_VERSION")) }
+  case node['platform_family']
+  when 'suse'
+    execute "initdb -d #{node['postgresql']['dir']}" do
+      user 'postgres'
+      not_if { ::File.exist?("#{node['postgresql']['config']['data_directory']}/PG_VERSION") }
+    end
+  else
+    execute "#{node['postgresql']['setup_script']} initdb #{svc_name}" do
+      not_if { ::File.exist?("#{node['postgresql']['config']['data_directory']}/PG_VERSION") }
+    end
   end
 
-elsif !platform_family?("suse")
+elsif (!platform_family?("suse") && node['postgresql']['version'].to_f <= 9.3)
 
   execute "/sbin/service #{svc_name} initdb #{initdb_locale}" do
-    not_if { ::FileTest.exist?(File.join(dir, "PG_VERSION")) }
+    not_if { ::File.exist?("#{node['postgresql']['config']['data_directory']}/PG_VERSION") }
+  end
+
+else
+
+  execute "/sbin/service #{svc_name} initdb" do
+    not_if { ::File.exist?("#{node['postgresql']['config']['data_directory']}/PG_VERSION") }
   end
 
 end

--- a/recipes/yum_pgdg_postgresql.rb
+++ b/recipes/yum_pgdg_postgresql.rb
@@ -15,31 +15,22 @@
 # limitations under the License.
 #
 
-#######
-# Load the pgdgrepo_rpm_info method from libraries/default.rb
-::Chef::Recipe.send(:include, Opscode::PostgresqlHelpers)
-
 ######################################
-# Install the "PostgreSQL RPM Building Project - Yum Repository" through
-# the repo_rpm_url determined with pgdgrepo_rpm_info method from
-# libraries/default.rb. The /etc/yum.repos.d/pgdg-*.repo
-# will provide postgresql9X packages, but you may need to exclude
-# postgresql packages from the repository of the distro in order to use
-# PGDG repository properly. Conflicts will arise if postgresql9X does
-# appear in your distro's repo and you want a more recent patch level.
+# Install the "PostgreSQL RPM Building Project - Yum Repository"
 
-repo_rpm_url, repo_rpm_filename, repo_rpm_package = pgdgrepo_rpm_info
+rpm_platform = node['platform']
+rpm_platform_version = node['platform_version'].to_f.to_i.to_s
+arch = node['kernel']['machine']
 
 # Download the PGDG repository RPM as a local file
-remote_file "#{Chef::Config[:file_cache_path]}/#{repo_rpm_filename}" do
-  source repo_rpm_url
+remote_file "#{Chef::Config[:file_cache_path]}/#{node[:postgresql][:pgdg][:repo_rpm_url][node[:postgresql][:version]][rpm_platform][rpm_platform_version][arch][:package]}" do
+  source "#{node[:postgresql][:pgdg][:repo_rpm_url][node[:postgresql][:version]][rpm_platform][rpm_platform_version][arch][:url]}#{node[:postgresql][:pgdg][:repo_rpm_url][node[:postgresql][:version]][rpm_platform][rpm_platform_version][arch][:package]}"
   mode "0644"
 end
 
 # Install the PGDG repository RPM from the local file
-# E.g., /etc/yum.repos.d/pgdg-91-centos.repo
-package repo_rpm_package do
+package "#{node[:postgresql][:pgdg][:repo_rpm_url][node[:postgresql][:version]][rpm_platform][rpm_platform_version][arch][:package]}" do
   provider Chef::Provider::Package::Rpm
-  source "#{Chef::Config[:file_cache_path]}/#{repo_rpm_filename}"
+  source "#{Chef::Config[:file_cache_path]}/#{node[:postgresql][:pgdg][:repo_rpm_url][node[:postgresql][:version]][rpm_platform][rpm_platform_version][arch][:package]}"
   action :install
 end

--- a/test/unit/default_spec.rb
+++ b/test/unit/default_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'postgresql::default' do
   platforms = {
     'ubuntu' => {
-      'versions' => ['10.04', '12.04', '14.04']
+      'versions' => ['12.04', '14.04']
      },
     'centos' => {
        'versions' => ['6.4', '7.0']

--- a/test/unit/opensuse_131_server_spec.rb
+++ b/test/unit/opensuse_131_server_spec.rb
@@ -59,7 +59,7 @@ describe 'opensuse::postgresql::server' do
   end
 
   it 'Launch Cluster Creation' do
-    expect(chef_run).to run_execute('/sbin/service postgresql initdb UTF-8')
+    expect(chef_run).to run_execute('initdb -d /var/lib/pgsql/data')
   end
 
   context 'Directory /etc/sysconfig/pgsql exist' do

--- a/test/unit/opensuse_132_server_spec.rb
+++ b/test/unit/opensuse_132_server_spec.rb
@@ -59,7 +59,7 @@ describe 'opensuse::postgresql::server' do
   end
 
   it 'Launch Cluster Creation' do
-    expect(chef_run).to run_execute('/sbin/service postgresql initdb UTF-8')
+    expect(chef_run).to run_execute('initdb -d /var/lib/pgsql/data')
   end
 
   context 'Directory /etc/sysconfig/pgsql exist' do

--- a/test/unit/server_spec.rb
+++ b/test/unit/server_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'postgresql::server' do
   platforms = {
     'ubuntu' => {
-      'versions' => ['10.04', '12.04', '14.04']
+      'versions' => ['12.04', '14.04']
      },
     'centos' => {
        'versions' => ['6.4', '7.0']


### PR DESCRIPTION
### Major Version Release

v4.0.0
-----
* No more derived attributes in the attributes file
* Correct issues which caused the inability to override installation version defaults
* Remove method pgdgrepo_rpm_info compile time use of derived attributes case many issues
* Use correct directory path and check for the correct not_if condition to determine if the database has been initialized
* Ensure that correct packages are installed in all scenarios where pg gem is compiled
* Updates to test-kitchen suite configuration

### Overview

There are a number of changes in this cookbook release. The end result is that we are now able to correctly override which version of Postgresql is being installed and from what source with a wrapping recipe. 

Here is an example for installing 9.4 from pgdg on Centos

```
node.set['postgresql']['enable_pgdg_yum'] = true

node.set['postgresql']['version'] = "9.4"

node.set['postgresql']['setup_script'] = "postgresql94-setup"

if node['postgresql']['enable_pgdg_yum']
  node.set['postgresql']['server']['service_name'] = "postgresql-9.4"
  node.set['postgresql']['server']['packages'] = ["postgresql94-server"]
  node.set['postgresql']['client']['packages'] = ["postgresql94", "postgresql94-devel"]
end

node.set['postgresql']['password']['postgres'] = "thispassword"

include_recipe "postgresql::ruby"
include_recipe "postgresql::server"
```

Here is an example of installing 9.4 from pgdg repositories on Ubuntu

```
node.set['postgresql']['enable_pgdg_apt'] = true

node.set['postgresql']['version'] = "9.4"

node.set['postgresql']['setup_script'] = "postgresql94-setup"

if node['postgresql']['enable_pgdg_apt']
  node.set['postgresql']['dir'] = '/etc/postgresql/9.4/main'
  node.set['postgresql']['server']['service_name'] = "postgresql"
  node.set['postgresql']['server']['packages'] = ["postgresql-9.4"]
  node.set['postgresql']['client']['packages'] = ["postgresql-client-9.4", "libpq-dev"]
end

node.set['postgresql']['password']['postgres'] = "thispassword"

include_recipe "postgresql::ruby"
include_recipe "postgresql::server"
```

`default['postgresq']['pgdg']['repo_rpm_url']`is now defined in the file `attributes/yum_pgdg_packages.rb` and there is a format change. See the example below.

```
default['postgresql']['pgdg']['repo_rpm_url'] = {
  "9.4" => {
    "redhat" => {
      "7" => {
        "x86_64" => {
          "url" => "http://yum.postgresql.org/9.4/redhat/rhel-7-x86_64/",
          "package" => "pgdg-redhat94-9.4-1.noarch.rpm"
        }
      }
  }
}
```

Additionally, we now only track configuration information in this hash for postgresql 9.2, 9.3 and 9.4. Previous versions are deprecated in the main cookbook.