### PR TITLE
Updated version of chefspec required from '~> 4.2.0' to '~> 4.5.0'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,5 @@ group :integration do
   gem 'kitchen-vagrant'
   gem 'kitchen-docker'
 end
-gem 'chefspec', '~> 4.2.0'
+gem 'chefspec', '~> 4.5.0'
 gem 'librarian-chef'


### PR DESCRIPTION
Updated version of chefspec required from '~> 4.2.0' to '~> 4.5.0'.

See: https://github.com/hw-cookbooks/postgresql/issues/321