### PR TITLE
Update pgdg packages for 9.4, 9.3

### DIFF
--- a/attributes/yum_pgdg_packages.rb
+++ b/attributes/yum_pgdg_packages.rb
@@ -10,27 +10,27 @@ default['postgresql']['pgdg']['repo_rpm_url'] = {
       "7" => {
         "x86_64" => {
           "url" => "http://yum.postgresql.org/9.4/redhat/rhel-7-x86_64/",
-          "package" => "pgdg-redhat94-9.4-1.noarch.rpm"
+          "package" => "pgdg-redhat94-9.4-2.noarch.rpm"
         }
       },
       "6" => {
         "i386" => {
           "url" => "http://yum.postgresql.org/9.4/redhat/rhel-6-i386/",
-          "package" => "pgdg-redhat94-9.4-1.noarch.rpm"
+          "package" => "pgdg-redhat94-9.4-2.noarch.rpm"
         },
         "x86_64" => {
           "url" => "http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/",
-          "package" => "pgdg-redhat94-9.4-1.noarch.rpm"
+          "package" => "pgdg-redhat94-9.4-2.noarch.rpm"
         }
       },
       "5" => {
         "i386" => {
           "url" => "http://yum.postgresql.org/9.4/redhat/rhel-5-i386/",
-          "package" => "pgdg-redhat94-9.4-1.noarch.rpm"
+          "package" => "pgdg-redhat94-9.4-2.noarch.rpm"
         },
         "x86_64" => {
           "url" => "http://yum.postgresql.org/9.4/redhat/rhel-5-x86_64/",
-          "package" => "pgdg-redhat94-9.4-1.noarch.rpm"
+          "package" => "pgdg-redhat94-9.4-2.noarch.rpm"
         }
       }
     },
@@ -38,27 +38,27 @@ default['postgresql']['pgdg']['repo_rpm_url'] = {
       "7" => {
         "x86_64" => {
           "url" => "http://yum.postgresql.org/9.4/redhat/rhel-7-x86_64/",
-          "package" => "pgdg-centos94-9.4-1.noarch.rpm"
+          "package" => "pgdg-centos94-9.4-2.noarch.rpm"
         }
       },
       "6" => {
         "i386" => {
           "url" => "http://yum.postgresql.org/9.4/redhat/rhel-6-i386/",
-          "package" => "pgdg-centos94-9.4-1.noarch.rpm"
+          "package" => "pgdg-centos94-9.4-2.noarch.rpm"
         },
         "x86_64" => {
           "url" => "http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/",
-          "package" => "pgdg-centos94-9.4-1.noarch.rpm"
+          "package" => "pgdg-centos94-9.4-2.noarch.rpm"
         }
       },
       "5" => {
         "x86_64" => {
           "url" => "http://yum.postgresql.org/9.4/redhat/rhel-5-x86_64/",
-          "package" => "pgdg-centos94-9.4-1.noarch.rpm"
+          "package" => "pgdg-centos94-9.4-2.noarch.rpm"
         },
         "i386" => {
           "url" => "http://yum.postgresql.org/9.4/redhat/rhel-5-i386/",
-          "package" => "pgdg-centos94-9.4-1.noarch.rpm"
+          "package" => "pgdg-centos94-9.4-2.noarch.rpm"
         }
       }
     },
@@ -94,11 +94,11 @@ default['postgresql']['pgdg']['repo_rpm_url'] = {
       "2015" => {
         "i386" => {
           "url" => "http://yum.postgresql.org/9.4/redhat/rhel-6-i386/",
-          "package" => "pgdg-ami201503-94-9.4-1.noarch.rpm"
+          "package" => "pgdg-ami201503-94-9.4-2.noarch.rpm"
         },
         "x86_64" => {
           "url" => "http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/",
-          "package" => "pgdg-ami201503-94-9.4-1.noarch.rpm"
+          "package" => "pgdg-ami201503-94-9.4-2.noarch.rpm"
         }
       }
     },
@@ -106,27 +106,27 @@ default['postgresql']['pgdg']['repo_rpm_url'] = {
       "7" => {
         "x86_64" => {
           "url" => "http://yum.postgresql.org/9.4/redhat/rhel-7-x86_64/",
-          "package" => "pgdg-sl94-9.4-1.noarch.rpm"
+          "package" => "pgdg-sl94-9.4-2.noarch.rpm"
         }
       },
       "6" => {
         "i386" => {
           "url" => "http://yum.postgresql.org/9.4/redhat/rhel-6-i386/",
-          "package" => "pgdg-sl94-9.4-1.noarch.rpm"
+          "package" => "pgdg-sl94-9.4-2.noarch.rpm"
         },
         "x86_64" => {
           "url" => "http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/",
-          "package" => "pgdg-sl94-9.4-1.noarch.rpm"
+          "package" => "pgdg-sl94-9.4-2.noarch.rpm"
         }
       },
       "5" => {
         "i386" => {
           "url" => "http://yum.postgresql.org/9.4/redhat/rhel-5-i386/",
-          "package" => "pgdg-sl94-9.4-1.noarch.rpm"
+          "package" => "pgdg-sl94-9.4-2.noarch.rpm"
         },
         "x86_64" => {
           "url" => "http://yum.postgresql.org/9.4/redhat/rhel-5-x86_64/",
-          "package" => "pgdg-sl94-9.4-1.noarch.rpm"
+          "package" => "pgdg-sl94-9.4-2.noarch.rpm"
         }
       }
     },
@@ -134,17 +134,17 @@ default['postgresql']['pgdg']['repo_rpm_url'] = {
       "7" => {
         "x86_64" => {
           "url" => "http://yum.postgresql.org/9.4/redhat/rhel-7-x86_64/",
-          "package" => "pgdg-oraclelinux94-9.4-1.noarch.rpm"
+          "package" => "pgdg-oraclelinux94-9.4-2.noarch.rpm"
         }
       },
       "6" => {
         "i386" => {
           "url" => "http://yum.postgresql.org/9.4/redhat/rhel-6-i386/",
-          "package" => "pgdg-oraclelinux94-9.4-1.noarch.rpm"
+          "package" => "pgdg-oraclelinux94-9.4-2.noarch.rpm"
         },
         "x86_64" => {
           "url" => "http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/",
-          "package" => "pgdg-oraclelinux94-9.4-1.noarch.rpm"
+          "package" => "pgdg-oraclelinux94-9.4-2.noarch.rpm"
         }
       }
     }
@@ -154,31 +154,31 @@ default['postgresql']['pgdg']['repo_rpm_url'] = {
       "2015" => {
         "i386" => {
           "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-i386/",
-          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+          "package" => "pgdg-redhat93-9.3-2.noarch.rpm"
         },
         "x86_64" => {
           "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-x86_64/",
-          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+          "package" => "pgdg-redhat93-9.3-2.noarch.rpm"
         }
       },
       "2014" => {
         "i386" => {
           "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-i386/",
-          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+          "package" => "pgdg-redhat93-9.3-2.noarch.rpm"
         },
         "x86_64" => {
           "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-x86_64/",
-          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+          "package" => "pgdg-redhat93-9.3-2.noarch.rpm"
         }
       },
       "2013" => {
         "i386" => {
           "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-i386/",
-          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+          "package" => "pgdg-redhat93-9.3-2.noarch.rpm"
         },
         "x86_64" => {
           "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-x86_64/",
-          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+          "package" => "pgdg-redhat93-9.3-2.noarch.rpm"
         }
       }
     },
@@ -186,27 +186,27 @@ default['postgresql']['pgdg']['repo_rpm_url'] = {
       "7" => {
         "x86_64" => {
           "url" => "http://yum.postgresql.org/9.3/redhat/rhel-7-x86_64/",
-          "package" => "pgdg-centos93-9.3-1.noarch.rpm"
+          "package" => "pgdg-centos93-9.3-2.noarch.rpm"
         }
       },
       "6" => {
         "i386" => {
           "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-i386/",
-          "package" => "pgdg-centos93-9.3-1.noarch.rpm"
+          "package" => "pgdg-centos93-9.3-2.noarch.rpm"
         },
         "x86_64" => {
           "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-x86_64/",
-          "package" => "pgdg-centos93-9.3-1.noarch.rpm"
+          "package" => "pgdg-centos93-9.3-2.noarch.rpm"
         }
       },
       "5" => {
         "i386" => {
           "url" => "http://yum.postgresql.org/9.3/redhat/rhel-5-i386/",
-          "package" => "pgdg-centos93-9.3-1.noarch.rpm"
+          "package" => "pgdg-centos93-9.3-2.noarch.rpm"
         },
         "x86_64" => {
           "url" => "http://yum.postgresql.org/9.3/redhat/rhel-5-x86_64/",
-          "package" => "pgdg-centos93-9.3-1.noarch.rpm"
+          "package" => "pgdg-centos93-9.3-2.noarch.rpm"
         }
       }
     },
@@ -214,27 +214,27 @@ default['postgresql']['pgdg']['repo_rpm_url'] = {
       "7" => {
         "x86_64" => {
           "url" => "http://yum.postgresql.org/9.3/redhat/rhel-7-x86_64/",
-          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+          "package" => "pgdg-redhat93-9.3-2.noarch.rpm"
         }
       },
       "6" => {
         "i386" => {
           "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-i386/",
-          "package" => "pgdg-redhat93-9.3-1.noarch.rpm",
+          "package" => "pgdg-redhat93-9.3-2.noarch.rpm",
         },
         "x86_64" => {
           "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-x86_64/",
-          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+          "package" => "pgdg-redhat93-9.3-2.noarch.rpm"
         }
       },
       "5" => {
         "i386" => {
           "url" => "http://yum.postgresql.org/9.3/redhat/rhel-5-i386/",
-          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+          "package" => "pgdg-redhat93-9.3-2.noarch.rpm"
         },
         "x86_64" => {
           "url" => "http://yum.postgresql.org/9.3/redhat/rhel-5-x86_64/",
-          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+          "package" => "pgdg-redhat93-9.3-2.noarch.rpm"
         }
       }
     },
@@ -242,21 +242,21 @@ default['postgresql']['pgdg']['repo_rpm_url'] = {
       "6" => {
         "i386" => {
           "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-i386/",
-          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+          "package" => "pgdg-redhat93-9.3-2.noarch.rpm"
         },
         "x86_64" => {
           "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-x86_64/",
-          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+          "package" => "pgdg-redhat93-9.3-2.noarch.rpm"
         }
       },
       "5" => {
         "i386" => {
           "url" => "http://yum.postgresql.org/9.3/redhat/rhel-5-i386/",
-          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+          "package" => "pgdg-redhat93-9.3-2.noarch.rpm"
         },
         "x86_64" => {
           "url" => "http://yum.postgresql.org/9.3/redhat/rhel-5-x86_64/",
-          "package" => "pgdg-redhat93-9.3-1.noarch.rpm"
+          "package" => "pgdg-redhat93-9.3-2.noarch.rpm"
         }
       }
     },
@@ -264,21 +264,21 @@ default['postgresql']['pgdg']['repo_rpm_url'] = {
       "6" => {
         "i386" => {
           "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-i386/",
-          "package" => "pgdg-sl93-9.3-1.noarch.rpm"
+          "package" => "pgdg-sl93-9.3-2.noarch.rpm"
         },
         "x86_64" => {
           "url" => "http://yum.postgresql.org/9.3/redhat/rhel-6-x86_64/",
-          "package" => "pgdg-sl93-9.3-1.noarch.rpm"
+          "package" => "pgdg-sl93-9.3-2.noarch.rpm"
         }
       },
       "5" => {
         "i386" => {
           "url" => "http://yum.postgresql.org/9.3/redhat/rhel-5-i386/",
-          "package" => "pgdg-sl93-9.3-1.noarch.rpm"
+          "package" => "pgdg-sl93-9.3-2.noarch.rpm"
         },
         "x86_64" => {
           "url" => "http://yum.postgresql.org/9.3/redhat/rhel-5-x86_64/",
-          "package" => "pgdg-sl93-9.3-1.noarch.rpm"
+          "package" => "pgdg-sl93-9.3-2.noarch.rpm"
         }
       }
     },


### PR DESCRIPTION
Getting some errors like 
```STDERR: package pgdg-centos94-9.4-2.noarch (which is newer than pgdg-centos94-9.4-1.noarch) is already installed```

... so we should bump the default version to the current one