### PR TITLE
Include attribute flag for organizations which are using internal copies of the pgdg packages

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,6 +17,7 @@
 
 default['postgresql']['enable_pgdg_apt'] = false
 default['postgresql']['enable_pgdg_yum'] = false
+default['postgresql']['use_pgdg_packages'] = false
 
 default['postgresql']['server']['config_change_notify'] = :restart
 default['postgresql']['assign_postgres_password'] = true

--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -32,11 +32,13 @@ rescue LoadError
   node.set['build-essential']['compile_time'] = true
   include_recipe "build-essential"
 
-  if node['postgresql']['enable_pgdg_yum']
+  if node['postgresql']['enable_pgdg_yum'] || node['postgresql']['use_pgdg_packages']
     package "ca-certificates" do
       action :nothing
     end.run_action(:upgrade)
-
+  end
+  
+  if node['postgresql']['enable_pgdg_yum']
     include_recipe "postgresql::yum_pgdg_postgresql"
 
     rpm_platform = node['platform']

--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -32,13 +32,11 @@ rescue LoadError
   node.set['build-essential']['compile_time'] = true
   include_recipe "build-essential"
 
-  if node['postgresql']['enable_pgdg_yum'] || node['postgresql']['use_pgdg_packages']
+  if node['postgresql']['enable_pgdg_yum']
     package "ca-certificates" do
       action :nothing
     end.run_action(:upgrade)
-  end
-  
-  if node['postgresql']['enable_pgdg_yum']
+
     include_recipe "postgresql::yum_pgdg_postgresql"
 
     rpm_platform = node['platform']

--- a/recipes/server_redhat.rb
+++ b/recipes/server_redhat.rb
@@ -53,7 +53,7 @@ node['postgresql']['server']['packages'].each do |pg_pack|
 end
 
 # If using PGDG, add symlinks so that downstream commands all work
-if node['postgresql']['enable_pgdg_yum'] == true
+if node['postgresql']['enable_pgdg_yum'] == true || node['postgresql']['use_pgdg_packages'] == true
   [
     "postgresql#{shortver}-setup",
     "postgresql#{shortver}-check-db-dir"


### PR DESCRIPTION
Hello,

Hope this PR finds you well.  I am requesting this change be included as it is necessary for clean use of this cookbook when wrapped by organizations which maintain their own internal repositories with separate code-signing requirements.  In this case, I am using pgdg packages, but not from the upstream repository, and do not wish to enable it in order to trigger the correct actions to occur.  I have no doubt I am not the only one that might be in this situation.  Best practices say not to fork upstream cookbooks to wrap them, so I am submitting this change to make this possible cleanly.

Thanks.