### PR TITLE
fix recipes for Ubuntu 16.04 LTS

### DIFF
--- a/recipes/apt_pgdg_postgresql.rb
+++ b/recipes/apt_pgdg_postgresql.rb
@@ -1,4 +1,4 @@
-if not %w(jessie squeeze wheezy sid lucid precise saucy trusty utopic).include? node['postgresql']['pgdg']['release_apt_codename']
+if not %w(jessie squeeze wheezy sid lucid precise saucy trusty utopic xenial).include? node['postgresql']['pgdg']['release_apt_codename']
   raise "Not supported release by PGDG apt repository"
 end
 

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -19,10 +19,6 @@ include_recipe "postgresql::ca_certificates"
 
 case node['platform_family']
 when 'debian'
-  if node['postgresql']['version'].to_f > 9.3
-    node.set['postgresql']['enable_pgdg_apt'] = true
-  end
-
   if node['postgresql']['enable_pgdg_apt']
     include_recipe 'postgresql::apt_pgdg_postgresql'
   end


### PR DESCRIPTION
The upcoming Ubuntu 16.04 is being shipped with Postgres 9.5.
The postgresql::client recipe is now forcing enable_pgdg_apt when version is > 9.3, so it always force using PDDG APT, even if I just want to use the packaged version already installed with Ubuntu 16.04.

In this PR I removed this check, since I think it is too strict and dependent on which debian-flavoured Linux distribution one is using.