### PR TITLE
Newer Platforms for test-kitchen

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -2,6 +2,10 @@
 driver_plugin: vagrant
 
 platforms:
+- name: ubuntu-15.04
+  run_list:
+  - recipe[apt]
+
 - name: ubuntu-14.04
   run_list:
   - recipe[apt]
@@ -61,7 +65,7 @@ suites:
   run_list:
   - recipe[minitest-handler]
   - recipe[postgresql]
-  excludes: [ "ubuntu-12.04", "ubuntu-14.04", "debian-8.2", "opensuse-13.1", "opensuse-13.2" ]
+  excludes: [ "ubuntu-12.04", "ubuntu-14.04", "ubuntu-15.04", "debian-8.2", "opensuse-13.1", "opensuse-13.2" ]
   attributes:
     postgresql:
       enable_pgdg_yum: true
@@ -113,7 +117,7 @@ suites:
   - recipe[minitest-handler]
   - recipe[postgresql::ruby]
   - recipe[postgresql::server]
-  excludes: [ "ubuntu-12.04", "ubuntu-14.04", "debian-8.2", "opensuse-13.1", "opensuse-13.2" ]
+  excludes: [ "ubuntu-12.04", "ubuntu-14.04", "ubuntu-15.04", "debian-8.2", "opensuse-13.1", "opensuse-13.2" ]
   attributes:
     postgresql:
       enable_pgdg_yum: true
@@ -145,7 +149,7 @@ suites:
   - recipe[minitest-handler]
   - recipe[postgresql]
   - recipe[postgresql::ruby]
-  excludes: [ "ubuntu-12.04", "ubuntu-14.04", "debian-8.2", "opensuse-13.1", "opensuse-13.2" ]
+  excludes: [ "ubuntu-12.04", "ubuntu-14.04", "ubuntu-15.04", "debian-8.2", "opensuse-13.1", "opensuse-13.2" ]
   attributes:
     postgresql:
       enable_pgdg_yum: true
@@ -184,7 +188,7 @@ suites:
   - recipe[minitest-handler]
   - recipe[postgresql::ruby]
   - recipe[postgresql::contrib]
-  excludes: [ "ubuntu-12.04", "ubuntu-14.04", "debian-8.2", "opensuse-13.1", "opensuse-13.2" ]
+  excludes: [ "ubuntu-12.04", "ubuntu-14.04", "ubuntu-15.04", "debian-8.2", "opensuse-13.1", "opensuse-13.2" ]
   attributes:
     postgresql:
       enable_pgdg_yum: true

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -14,6 +14,8 @@ platforms:
   run_list:
   - recipe[apt]
 
+- name: centos-7.2
+
 - name: centos-7.0
 
 - name: centos-6.4
@@ -47,7 +49,7 @@ suites:
   run_list:
   - recipe[minitest-handler]
   - recipe[postgresql]
-  excludes: [ "centos-6.4", "centos-7.0", "opensuse-13.1", "opensuse-13.2" ]
+  excludes: [ "centos-6.4", "centos-7.0", "centos-7.2", "opensuse-13.1", "opensuse-13.2" ]
   attributes:
     postgresql:
       enable_pgdg_apt: true
@@ -89,7 +91,7 @@ suites:
   - recipe[minitest-handler]
   - recipe[postgresql::ruby]
   - recipe[postgresql::server]
-  excludes: [ "centos-6.4", "centos-7.0", "opensuse-13.1", "opensuse-13.2" ]
+  excludes: [ "centos-6.4", "centos-7.0", "centos-7.2", "opensuse-13.1", "opensuse-13.2" ]
   attributes:
     postgresql:
       enable_pgdg_apt: true
@@ -130,7 +132,7 @@ suites:
   - recipe[minitest-handler]
   - recipe[postgresql]
   - recipe[postgresql::ruby]
-  excludes: [ "centos-6.4", "centos-7.0", "opensuse-13.1", "opensuse-13.2" ]
+  excludes: [ "centos-6.4", "centos-7.0", "centos-7.2", "opensuse-13.1", "opensuse-13.2" ]
   attributes:
     postgresql:
       enable_pgdg_apt: true
@@ -156,7 +158,7 @@ suites:
   - recipe[minitest-handler]
   - recipe[postgresql::ruby]
   - recipe[postgresql::contrib]
-  excludes: [ "centos-6.4", "centos-7.0", "opensuse-13.1", "opensuse-13.2" ]
+  excludes: [ "centos-6.4", "centos-7.0", "centos-7.2", "opensuse-13.1", "opensuse-13.2" ]
   attributes:
     postgresql:
       enable_pgdg_apt: true


### PR DESCRIPTION
Add new Platforms for test-kitchen
* 15.04 Ubuntu
* 7.2 Centos