### PR TITLE
add Ubuntu Wily Werewolf to supported pgdg apt repositories

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -12,7 +12,7 @@ recipe            "postgresql::server", "Installs postgresql server packages, te
 recipe            "postgresql::server_redhat", "Installs postgresql server packages, redhat family style"
 recipe            "postgresql::server_debian", "Installs postgresql server packages, debian family style"
 
-supports "ubuntu", "< 14.10"
+supports "ubuntu", "<= 15.10"
 
 %w{debian fedora suse opensuse amazon}.each do |os|
   supports os

--- a/recipes/apt_pgdg_postgresql.rb
+++ b/recipes/apt_pgdg_postgresql.rb
@@ -1,4 +1,4 @@
-if not %w(jessie squeeze wheezy sid lucid precise saucy trusty utopic).include? node['postgresql']['pgdg']['release_apt_codename']
+if not %w(jessie squeeze wheezy sid lucid precise saucy trusty utopic wily).include? node['postgresql']['pgdg']['release_apt_codename']
   raise "Not supported release by PGDG apt repository"
 end
 


### PR DESCRIPTION
Allows for the pgdg repositories to be used under Ubuntu 15.10

http://apt.postgresql.org/pub/repos/apt/dists/wily-pgdg/

It should be noted that there is no repository available for Ubuntu 15.04 Vivid.
