### PR TITLE
Add Support for Ubuntu 16.04

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -14,7 +14,7 @@ recipe            "postgresql::server", "Installs postgresql server packages, te
 recipe            "postgresql::server_redhat", "Installs postgresql server packages, redhat family style"
 recipe            "postgresql::server_debian", "Installs postgresql server packages, debian family style"
 
-supports "ubuntu", "<= 15.10"
+supports "ubuntu", "<= 16.04"
 
 %w{debian fedora suse opensuse amazon}.each do |os|
   supports os

--- a/recipes/apt_pgdg_postgresql.rb
+++ b/recipes/apt_pgdg_postgresql.rb
@@ -1,4 +1,4 @@
-if not %w(jessie squeeze wheezy sid lucid precise saucy trusty utopic wily).include? node['postgresql']['pgdg']['release_apt_codename']
+if not %w(jessie squeeze wheezy sid lucid precise saucy trusty utopic wily xenial).include? node['postgresql']['pgdg']['release_apt_codename']
   raise "Not supported release by PGDG apt repository"
 end
 


### PR DESCRIPTION
According to [the docs](https://wiki.postgresql.org/wiki/Apt), PGDG now has packages for 16.04 Xenial. This should now be allowed to be used here.