### PR TITLE
Support install system packages on Ubuntu 16.04

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -132,13 +132,20 @@ when "ubuntu"
     default['postgresql']['client']['packages'] = ["postgresql-client-9.1", "libpq-dev"]
     default['postgresql']['server']['packages'] = ["postgresql-9.1"]
     default['postgresql']['contrib']['packages'] = ["postgresql-contrib-9.1"]
-  else
+  when node['platform_version'].to_f <= 15.10
     default['postgresql']['version'] = "9.3"
     default['postgresql']['dir'] = "/etc/postgresql/9.3/main"
     default['postgresql']['server']['service_name'] = "postgresql"
     default['postgresql']['client']['packages'] = ["postgresql-client-9.3", "libpq-dev"]
     default['postgresql']['server']['packages'] = ["postgresql-9.3"]
     default['postgresql']['contrib']['packages'] = ["postgresql-contrib-9.3"]
+  else
+    default['postgresql']['version'] = "9.5"
+    default['postgresql']['dir'] = "/etc/postgresql/9.5/main"
+    default['postgresql']['server']['service_name'] = "postgresql"
+    default['postgresql']['client']['packages'] = ["postgresql-client-9.5", "libpq-dev"]
+    default['postgresql']['server']['packages'] = ["postgresql-9.5"]
+    default['postgresql']['contrib']['packages'] = ["postgresql-contrib-9.5"]
   end
 
 when "fedora"

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -19,8 +19,14 @@ include_recipe "postgresql::ca_certificates"
 
 case node['platform_family']
 when 'debian'
-  if node['postgresql']['version'].to_f > 9.3
-    node.set['postgresql']['enable_pgdg_apt'] = true
+  if node['platform'] == 'ubuntu' and node['platform_version'].to_f >= 16.04
+    if node['postgresql']['version'].to_f > 9.5
+      node.set['postgresql']['enable_pgdg_apt'] = true
+    end
+  else
+    if node['postgresql']['version'].to_f > 9.3
+      node.set['postgresql']['enable_pgdg_apt'] = true
+    end
   end
 
   if node['postgresql']['enable_pgdg_apt']


### PR DESCRIPTION
Just a small change so the cookbook can install the system default postgresql packages that come with Ubuntu 16.04.

Also adds a check so that the pgdg repo is not automatically turned on when requesting the ubuntu supplied packages.