### PR TITLE
Add support for Ubuntu 16.04

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -2,6 +2,10 @@
 driver_plugin: vagrant
 
 platforms:
+- name: ubuntu-16.04
+  run_list:
+  - recipe[apt]
+
 - name: ubuntu-15.04
   run_list:
   - recipe[apt]
@@ -65,7 +69,7 @@ suites:
   run_list:
   - recipe[minitest-handler]
   - recipe[postgresql]
-  excludes: [ "ubuntu-12.04", "ubuntu-14.04", "ubuntu-15.04", "debian-8.2", "opensuse-13.1", "opensuse-13.2" ]
+  excludes: [ "ubuntu-12.04", "ubuntu-14.04", "ubuntu-15.04", "ubuntu-16.04", "debian-8.2", "opensuse-13.1", "opensuse-13.2" ]
   attributes:
     postgresql:
       enable_pgdg_yum: true
@@ -117,7 +121,7 @@ suites:
   - recipe[minitest-handler]
   - recipe[postgresql::ruby]
   - recipe[postgresql::server]
-  excludes: [ "ubuntu-12.04", "ubuntu-14.04", "ubuntu-15.04", "debian-8.2", "opensuse-13.1", "opensuse-13.2" ]
+  excludes: [ "ubuntu-12.04", "ubuntu-14.04", "ubuntu-15.04", "ubuntu-16.04", "debian-8.2", "opensuse-13.1", "opensuse-13.2" ]
   attributes:
     postgresql:
       enable_pgdg_yum: true
@@ -149,7 +153,7 @@ suites:
   - recipe[minitest-handler]
   - recipe[postgresql]
   - recipe[postgresql::ruby]
-  excludes: [ "ubuntu-12.04", "ubuntu-14.04", "ubuntu-15.04", "debian-8.2", "opensuse-13.1", "opensuse-13.2" ]
+  excludes: [ "ubuntu-12.04", "ubuntu-14.04", "ubuntu-15.04", "ubuntu-16.04", "debian-8.2", "opensuse-13.1", "opensuse-13.2" ]
   attributes:
     postgresql:
       enable_pgdg_yum: true
@@ -188,7 +192,7 @@ suites:
   - recipe[minitest-handler]
   - recipe[postgresql::ruby]
   - recipe[postgresql::contrib]
-  excludes: [ "ubuntu-12.04", "ubuntu-14.04", "ubuntu-15.04", "debian-8.2", "opensuse-13.1", "opensuse-13.2" ]
+  excludes: [ "ubuntu-12.04", "ubuntu-14.04", "ubuntu-15.04", "ubuntu-16.04", "debian-8.2", "opensuse-13.1", "opensuse-13.2" ]
   attributes:
     postgresql:
       enable_pgdg_yum: true

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -132,13 +132,27 @@ when "ubuntu"
     default['postgresql']['client']['packages'] = ["postgresql-client-9.1", "libpq-dev"]
     default['postgresql']['server']['packages'] = ["postgresql-9.1"]
     default['postgresql']['contrib']['packages'] = ["postgresql-contrib-9.1"]
-  else
+  when node['platform_version'].to_f <= 14.04
     default['postgresql']['version'] = "9.3"
     default['postgresql']['dir'] = "/etc/postgresql/9.3/main"
     default['postgresql']['server']['service_name'] = "postgresql"
     default['postgresql']['client']['packages'] = ["postgresql-client-9.3", "libpq-dev"]
     default['postgresql']['server']['packages'] = ["postgresql-9.3"]
     default['postgresql']['contrib']['packages'] = ["postgresql-contrib-9.3"]
+  when node['platform_version'].to_f <= 15.10
+    default['postgresql']['version'] = "9.4"
+    default['postgresql']['dir'] = "/etc/postgresql/9.4/main"
+    default['postgresql']['server']['service_name'] = "postgresql"
+    default['postgresql']['client']['packages'] = ["postgresql-client-9.4", "libpq-dev"]
+    default['postgresql']['server']['packages'] = ["postgresql-9.4"]
+    default['postgresql']['contrib']['packages'] = ["postgresql-contrib-9.4"]
+  else
+    default['postgresql']['version'] = "9.5"
+    default['postgresql']['dir'] = "/etc/postgresql/9.5/main"
+    default['postgresql']['server']['service_name'] = "postgresql"
+    default['postgresql']['client']['packages'] = ["postgresql-client-9.5", "libpq-dev"]
+    default['postgresql']['server']['packages'] = ["postgresql-9.5"]
+    default['postgresql']['contrib']['packages'] = ["postgresql-contrib-9.5"]
   end
 
 when "fedora"

--- a/files/default/tests/minitest/apt_pgdg_postgresql_test.rb
+++ b/files/default/tests/minitest/apt_pgdg_postgresql_test.rb
@@ -28,12 +28,12 @@ describe 'postgresql::apt_pgdg_postgresql' do
     file("/etc/apt/sources.list.d/apt.postgresql.org.list").must_exist
   end
 
-  it 'installs postgresql-client-9.4' do
-    package("postgresql-client-9.4").must_be_installed
+  it "installs postgresql-client-#{node['postgresql']['version']}" do
+    package("postgresql-client-#{node['postgresql']['version']}").must_be_installed
   end
 
-  it 'makes psql version 9.4 available' do
+  it "makes psql version #{node['postgresql']['version']} available" do
     psql = shell_out("psql --version")
-    assert psql.stdout.include?("psql (PostgreSQL) 9.4")
+    assert psql.stdout.include?("psql (PostgreSQL) #{node['postgresql']['version']}")
   end
 end


### PR DESCRIPTION
On [Ubuntu 16.04 default version of PostgreSQL is 9.5](http://packages.ubuntu.com/search?keywords=postgresql&searchon=names&suite=all&section=all), but this cookbook was still trying to install 9.3. So default attributes were completed and tests suites were added and verified.